### PR TITLE
Add configurable options

### DIFF
--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -3,7 +3,9 @@ from oic import rndstr
 from oic.oic import Client
 from oic.oic.message import AuthorizationResponse
 from oic.oic.message import EndSessionRequest
-from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from oic.oic.message import IdToken
+from pas.plugins.oidc.utils import CustomOpenIDNonBooleanSchema
+from pas.plugins.oidc.utils import SINGLE_OPTIONAL_BOOLEAN_AS_STRING
 from plone import api
 from Products.Five.browser import BrowserView
 
@@ -19,14 +21,14 @@ logger = logging.getLogger(__name__)
 # in produzione usare: https://pypi.org/project/Products.mcdutils/
 # XXX: attualmente implementata sessione su cookie
 class Session(object):
-    session_cookie_name = '__ac_session'
+    session_cookie_name = "__ac_session"
     _session = {}
 
     def __init__(self, request, use_session_data_manager=False):
         self.request = request
         self.use_session_data_manager = use_session_data_manager
         if self.use_session_data_manager:
-            sdm = api.portal.get_tool('session_data_manager')
+            sdm = api.portal.get_tool("session_data_manager")
             self._session = sdm.getSessionData(create=True)
         else:
             data = self.request.cookies.get(self.session_cookie_name) or {}
@@ -42,7 +44,7 @@ class Session(object):
                 self._session[name] = value
                 self.request.response.setCookie(
                     self.session_cookie_name,
-                    base64.b64encode(json.dumps(self._session).encode('utf-8'))
+                    base64.b64encode(json.dumps(self._session).encode("utf-8")),
                 )
 
     def get(self, name):
@@ -54,33 +56,33 @@ class Session(object):
 
 
 class LoginView(BrowserView):
-
     def __call__(self):
-        session = Session(self.request, use_session_data_manager=self.context.use_session_data_manager)
+        session = Session(
+            self.request, use_session_data_manager=self.context.use_session_data_manager
+        )
         # state is used to keep track of responses to outstanding requests (state).
         # nonce is a string value used to associate a Client session with an ID Token, and to mitigate replay attacks.
-        session.set('state', rndstr())
-        session.set('nonce', rndstr())
-
+        session.set("state", rndstr())
+        session.set("nonce", rndstr())
 
         client = self.context.get_oauth2_client()
 
         # https://pyoidc.readthedocs.io/en/latest/examples/rp.html#authorization-code-flow
         args = {
-            'client_id': self.context.client_id,
-            'response_type': 'code',
-            'scope': self.context.get_scopes(),
-            'state': session.get('state'),
-            'nonce': session.get('nonce'),
+            "client_id": self.context.client_id,
+            "response_type": "code",
+            "scope": self.context.get_scopes(),
+            "state": session.get("state"),
+            "nonce": session.get("nonce"),
             "redirect_uri": self.context.get_redirect_uris(),
         }
 
         if self.context.use_pkce:
             # Build a random string of 43 to 128 characters
             # and send it in the request as a base64-encoded urlsafe string of the sha256 hash of that string
-            session.set('verifier', rndstr(128))
-            args['code_challenge'] = self.get_code_challenge(session.get('verifier'))
-            args['code_challenge_method'] = 'S256'
+            session.set("verifier", rndstr(128))
+            args["code_challenge"] = self.get_code_challenge(session.get("verifier"))
+            args["code_challenge_method"] = "S256"
 
         auth_req = client.construct_AuthorizationRequest(request_args=args)
         login_url = auth_req.request(client.authorization_endpoint)
@@ -90,15 +92,14 @@ class LoginView(BrowserView):
 
     def get_code_challenge(self, value):
         """build a sha256 hash of the base64 encoded value of value
-           be careful: this should be url-safe base64 and we should also remove the trailing '='
-           See https://www.stefaanlippens.net/oauth-code-flow-pkce.html#PKCE-code-verifier-and-challenge
+        be careful: this should be url-safe base64 and we should also remove the trailing '='
+        See https://www.stefaanlippens.net/oauth-code-flow-pkce.html#PKCE-code-verifier-and-challenge
         """
         hash_code = sha256(value.encode("utf-8")).digest()
         return base64.urlsafe_b64encode(hash_code).decode("utf-8").replace("=", "")
 
 
 class LogoutView(BrowserView):
-
     def __call__(self):
         client = self.context.get_oauth2_client()
         # session = Session(self.request, use_session_data_manager=self.context.use_session_data_manager)
@@ -109,14 +110,14 @@ class LogoutView(BrowserView):
             # 'state': session.get('end_session_state'),
             # TODO: ....
             # 'post_logout_redirect_uri': api.portal.get().absolute_url(),
-            'redirect_uri': api.portal.get().absolute_url(),
+            "redirect_uri": api.portal.get().absolute_url(),
         }
         # end_req = client.construct_EndSessionRequest(request_args=args)
         end_req = EndSessionRequest(**args)
         logout_url = end_req.request(client.end_session_endpoint)
         self.request.response.setHeader("Cache-Control", "no-cache, must-revalidate")
-        self.request.response.expireCookie('__ac', path='/')
-        self.request.response.expireCookie('auth_token', path='/')
+        self.request.response.expireCookie("__ac", path="/")
+        self.request.response.expireCookie("auth_token", path="/")
         self.request.response.redirect(logout_url)
         return
 
@@ -124,13 +125,16 @@ class LogoutView(BrowserView):
 class CallbackView(BrowserView):
     def __call__(self):
         response = self.request.environ["QUERY_STRING"]
-        session = Session(self.request, use_session_data_manager=self.context.use_session_data_manager)
+        session = Session(
+            self.request, use_session_data_manager=self.context.use_session_data_manager
+        )
         client = self.context.get_oauth2_client()
         aresp = client.parse_response(
-            AuthorizationResponse, info=response, sformat="urlencoded")
+            AuthorizationResponse, info=response, sformat="urlencoded"
+        )
         # XXX: togliere debug e reinserire assert dopo aver trovato eventuali
         # anomalie
-        logger.info('DEBUG %s %s', aresp.get('state'), session.get('state'))
+        logger.info("DEBUG %s %s", aresp.get("state"), session.get("state"))
         # assert aresp["state"] == session.get("state")
         args = {
             "code": aresp["code"],
@@ -138,14 +142,36 @@ class CallbackView(BrowserView):
         }
 
         if self.context.use_pkce:
-            args['code_verifier'] = session.get('verifier')
+            args["code_verifier"] = session.get("verifier")
 
+        if self.context.use_modified_openid_schema:
+            IdToken.c_param.update(
+                {
+                    "email_verified": SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                    "phone_number_verified": SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                }
+            )
         resp = client.do_access_token_request(
             state=aresp["state"],
             request_args=args,
-            authn_method="client_secret_basic"
+            authn_method="client_secret_basic",
         )
-        userinfo = client.do_user_info_request(state=aresp["state"])
+
+        user_info_endpoint_exists = client.message_factory.get_request_type(
+            "userinfo_endpoint"
+        )()
+        if user_info_endpoint_exists:
+            # XXX: Not completely sure if this is even needed
+            #      We do not have a OpenID connect provider with userinfo endpoint
+            #      enabled and with the weird treatment of boolean values, so we cannot test this
+            # if self.context.use_modified_openid_schema:
+            #     userinfo = client.do_user_info_request(state=aresp["state"], user_info_schema=CustomOpenIDNonBooleanSchema)
+            # else:
+            #     userinfo = client.do_user_info_request(state=aresp["state"])
+            userinfo = client.do_user_info_request(state=aresp["state"])
+        else:
+            userinfo = resp.to_dict().get("id_token", {})
+
         # session.set('id_token', )
         self.context.rememberIdentity(userinfo)
         # TODO: manage next_url/came_from

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -63,9 +63,9 @@ class LoginView(BrowserView):
 
         # https://pyoidc.readthedocs.io/en/latest/examples/rp.html#authorization-code-flow
         args = {
-            'client_id': self.context.client_id, 
-            'response_type': 'code', 
-            'scope': ['profile', 'email', 'phone'],
+            'client_id': self.context.client_id,
+            'response_type': 'code',
+            'scope': self.context.get_scopes(),
             'state': session.get('state'),
             'nonce': session.get('nonce'),
             "redirect_uri": self.context.get_redirect_uris(),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -56,6 +56,7 @@ class OIDCPlugin(BasePlugin):
     create_user = True
     scope = ('profile', 'email', 'phone')
     use_pkce = False
+    use_modified_openid_schema = False
 
     _properties = (
         dict(id='issuer', type='string', mode='w',
@@ -78,6 +79,9 @@ class OIDCPlugin(BasePlugin):
              label='Open ID scopes to request to the server'),
         dict(id='use_pkce', type='boolean', mode='w',
              label='Use PKCE. '),
+        dict(id='use_modified_openid_schema', type='boolean', mode='w',
+             label="Use a modified OpenID Schema for email_verified and phone_number_verified boolean values coming as string. "),
+
 
     )
 
@@ -140,7 +144,9 @@ class OIDCPlugin(BasePlugin):
         userProps = {}
         if 'email' in userinfo:
             userProps['email'] = userinfo['email']
-        if 'name' in userinfo and 'family_name' in userinfo:
+        if 'given_name' in userinfo and 'family_name' in userinfo:
+            userProps['fullname'] = '{} {}'.format(userinfo['given_name'], userinfo['family_name'])
+        elif 'name' in userinfo and 'family_name' in userinfo:
             userProps['fullname'] = '{} {}'.format(userinfo['name'], userinfo['family_name'])
         # userProps[LAST_UPDATE_USER_PROPERTY_KEY] = time.time()
         if userProps:

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -55,6 +55,7 @@ class OIDCPlugin(BasePlugin):
     create_restapi_ticket = False
     create_user = True
     scope = ('profile', 'email', 'phone')
+    use_pkce = False
 
     _properties = (
         dict(id='issuer', type='string', mode='w',
@@ -75,6 +76,9 @@ class OIDCPlugin(BasePlugin):
              label='Create authentication auth_token (volto/restapi) ticket.'),
         dict(id='scope', type='lines', mode='w',
              label='Open ID scopes to request to the server'),
+        dict(id='use_pkce', type='boolean', mode='w',
+             label='Use PKCE. '),
+
     )
 
     def rememberIdentity(self, userinfo):
@@ -144,7 +148,7 @@ class OIDCPlugin(BasePlugin):
 
     def _generatePassword(self):
         """ Return a obfuscated password never used for login """
-        return ''.join([choice(PWCHARS) for ii in range(40)])        
+        return ''.join([choice(PWCHARS) for ii in range(40)])
 
     def _setupTicket(self, user_id):
         """Set up authentication ticket (__ac cookie) with plone.session.
@@ -189,7 +193,7 @@ class OIDCPlugin(BasePlugin):
     def get_oauth2_client(self):
         client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
         # registration_response = client.register(provider_info["registration_endpoint"], redirect_uris=...)
-        # ... oic.exception.RegistrationError: {'error': 'insufficient_scope', 
+        # ... oic.exception.RegistrationError: {'error': 'insufficient_scope',
         #     'error_description': "Policy 'Trusted Hosts' rejected request to client-registration service. Details: Host not trusted."}
 
         # use WebFinger

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -54,6 +54,7 @@ class OIDCPlugin(BasePlugin):
     create_ticket = True
     create_restapi_ticket = False
     create_user = True
+    scope = ('profile', 'email', 'phone')
 
     _properties = (
         dict(id='issuer', type='string', mode='w',
@@ -72,6 +73,8 @@ class OIDCPlugin(BasePlugin):
              label='Create authentication __ac ticket. '),
         dict(id='create_restapi_ticket', type='boolean', mode='w',
              label='Create authentication auth_token (volto/restapi) ticket.'),
+        dict(id='scope', type='lines', mode='w',
+             label='Open ID scopes to request to the server'),
     )
 
     def rememberIdentity(self, userinfo):
@@ -206,6 +209,12 @@ class OIDCPlugin(BasePlugin):
             return [
                 '{}/callback'.format(self.absolute_url()),
             ]
+
+    def get_scopes(self):
+        if self.scope:
+            return [u.decode('utf-8') for u in self.scope]
+        else:
+            return []
 
 
 InitializeClass(OIDCPlugin)

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -1,1 +1,56 @@
+from oic.oauth2.message import ParamDefinition
+from oic.oauth2.message import SINGLE_OPTIONAL_INT
+from oic.oauth2.message import SINGLE_OPTIONAL_STRING
+from oic.oauth2.message import SINGLE_REQUIRED_STRING
+from oic.oic.message import OpenIDSchema
+from oic.oic.message import OPTIONAL_ADDRESS
+from oic.oic.message import OPTIONAL_MESSAGE
+from oic.oic.message import SINGLE_OPTIONAL_BOOLEAN
+
 PLUGIN_ID = 'oidc'
+
+
+def boolean_string_ser(val, sformat=None, lev=0):
+    bool_value = bool(val)
+    return bool_value
+
+
+def boolean_string_deser(val, sformat=None, lev=0):
+    if isinstance(val, bool):
+        return val
+    else:
+        if val.lower() == 'true':
+            return True
+
+    return False
+
+
+# value type, required, serializer, deserializer, null value allowed
+SINGLE_OPTIONAL_BOOLEAN_AS_STRING = ParamDefinition(str, False, boolean_string_ser, boolean_string_deser, False)
+
+
+class CustomOpenIDNonBooleanSchema(OpenIDSchema):
+    c_param = {
+        "sub": SINGLE_REQUIRED_STRING,
+        "name": SINGLE_OPTIONAL_STRING,
+        "given_name": SINGLE_OPTIONAL_STRING,
+        "family_name": SINGLE_OPTIONAL_STRING,
+        "middle_name": SINGLE_OPTIONAL_STRING,
+        "nickname": SINGLE_OPTIONAL_STRING,
+        "preferred_username": SINGLE_OPTIONAL_STRING,
+        "profile": SINGLE_OPTIONAL_STRING,
+        "picture": SINGLE_OPTIONAL_STRING,
+        "website": SINGLE_OPTIONAL_STRING,
+        "email": SINGLE_OPTIONAL_STRING,
+        "email_verified": SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+        "gender": SINGLE_OPTIONAL_STRING,
+        "birthdate": SINGLE_OPTIONAL_STRING,
+        "zoneinfo": SINGLE_OPTIONAL_STRING,
+        "locale": SINGLE_OPTIONAL_STRING,
+        "phone_number": SINGLE_OPTIONAL_STRING,
+        "phone_number_verified": SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+        "address": OPTIONAL_ADDRESS,
+        "updated_at": SINGLE_OPTIONAL_INT,
+        "_claim_names": OPTIONAL_MESSAGE,
+        "_claim_sources": OPTIONAL_MESSAGE,
+    }


### PR DESCRIPTION
We have been working to use EU Login with this plugin because it implements OpenID connect.

Nevertheless we have found that we needed to do some changes in the implementation, such as:

- Add a configurable option to select which scopes to use
- Add an option to use [PKCE](https://www.stefaanlippens.net/oauth-code-flow-pkce.html)
- We found that EU Login has some strange implementation, where the `email_verified` and `phone_number_verified` boolean values are sent as string values (`'true'`), so the automatic validation that oidc library does fails with EU Login. So we have added an option to use a modified version of the validation that accepts `'true'` values as real JSON `true` and thus python `True`.
- We have also found that EU Login does not have the `userinfo` endpoint, so we now check if the endpoint exists before querying it. If the endpoint is not defined, we extract the userinfo from the id_token, with is already decoded in the previous step (obtaining the access_token).

We want also to work on the came_from/next_url thing, but had no time yet. Will check it after holidays :)