### PR TITLE
Call getProperty only once when getting redirect_uris or scope.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.0a4 (unreleased)
 ------------------
 
+- Call getProperty only once when getting redirect_uris or scope.
+  [maurits]
+
 - use getProperty accessor
   [mamico]
 
@@ -16,7 +19,7 @@ Changelog
   [alecghica]
 - Fixed Python compatibility with version >= 3.6
   [alecghica]
-- check if url is in portal before redirect #2 
+- check if url is in portal before redirect #2
   [erral]
 - manage came_from
   [mamico]

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -8,7 +8,6 @@ from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
 
 # from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 # from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
@@ -27,6 +26,12 @@ import itertools
 import logging
 import string
 
+try:
+    # Plone 6.0+
+    from plone.base.utils import safe_text
+except ImportError:
+    # Plone 5.2
+    from Products.CMFPlone.utils import safe_unicode as safe_text
 
 logger = logging.getLogger(__name__)
 # _MARKER = object()
@@ -241,18 +246,18 @@ class OIDCPlugin(BasePlugin):
         return client
 
     def get_redirect_uris(self):
-        if self.getProperty("redirect_uris"):
-            return [safe_unicode(u) for u in self.getProperty("redirect_uris")]
-        else:
-            return [
-                "{}/callback".format(self.absolute_url()),
-            ]
+        redirect_uris = self.getProperty("redirect_uris")
+        if redirect_uris:
+            return [safe_text(uri) for uri in redirect_uris if uri]
+        return [
+            "{}/callback".format(self.absolute_url()),
+        ]
 
     def get_scopes(self):
-        if self.getProperty("scope"):
-            return [safe_unicode(u) for u in self.getProperty("scope")]
-        else:
-            return []
+        scopes = self.getProperty("scope")
+        if scopes:
+            return [safe_text(scope) for scope in scopes if scope]
+        return []
 
 
 InitializeClass(OIDCPlugin)


### PR DESCRIPTION
Just a small bit of extra efficiency.
And don't return empty lines, just in case. 