### PR TITLE
Add challenge plugin: redirect to our own require_login page.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 1.0a5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update the plugin to make challenges.
+  An anonymous user who visits a page for which you have to be authenticated,
+  is redirected to the new require_login view on the plugin.
+  This works the same way as the standard require_login page of Plone.
+  [maurits]
 
 
 1.0a4 (2023-01-16)

--- a/src/pas/plugins/oidc/browser/configure.zcml
+++ b/src/pas/plugins/oidc/browser/configure.zcml
@@ -14,6 +14,14 @@
 
   <browser:page
       for="..plugins.IOIDCPlugin"
+      name="require_login"
+      class=".view.RequireLoginView"
+      layer="pas.plugins.oidc.interfaces.IPasPluginsOidcLayer"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="..plugins.IOIDCPlugin"
       name="logout"
       class=".view.LogoutView"
       layer="pas.plugins.oidc.interfaces.IPasPluginsOidcLayer"

--- a/src/pas/plugins/oidc/configure.zcml
+++ b/src/pas/plugins/oidc/configure.zcml
@@ -36,6 +36,14 @@
       post_handler=".setuphandlers.uninstall"
       />
 
+  <genericsetup:upgradeStep
+      title="Activate challenge plugin"
+      source="1000"
+      destination="1001"
+      profile="pas.plugins.oidc:default"
+      handler=".setuphandlers.activate_challenge_plugin"
+      />
+
   <utility
       factory=".setuphandlers.HiddenProfiles"
       name="pas.plugins.oidc-hiddenprofiles"

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -318,11 +318,14 @@ def safe_write(request):
     Inside the context manager objects can be written to without any
     restriction. The context manager collects all touched objects
     and marks them as safe write."""
-    objects_before = set(_registered_objects(request))
+    # We used 'set' here before, but that could lead to:
+    # TypeError: unhashable type: 'PersistentMapping'
+    objects_before = _registered_objects(request)
     yield
-    objects_after = set(_registered_objects(request))
-    for obj in objects_after - objects_before:
-        safeWrite(obj, request)
+    objects_after = _registered_objects(request)
+    for obj in objects_after:
+        if obj not in objects_before:
+            safeWrite(obj, request)
 
 
 def _registered_objects(request):

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -9,7 +9,7 @@ from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
 
-# from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
+from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 # from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
 # from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 # from Products.PluggableAuthService.interfaces.plugins import IRolesPlugin
@@ -272,6 +272,25 @@ class OIDCPlugin(BasePlugin):
             return [safe_text(scope) for scope in scopes if scope]
         return []
 
+    def challenge(self, request, response):
+        """Assert via the response that credentials will be gathered.
+
+        For IChallengePlugin.
+
+        Takes a REQUEST object and a RESPONSE object.
+
+        Must return True if it fired, False/None otherwise.
+
+        Note: if you are not logged in, and go to the login form,
+        everything will still work, and you will not be challenged.
+        A challenge is only tried when you are unauthorized.
+        """
+        # Go to the login view of the PAS plugin.
+        logger.info("Challenge. Came from %s", request.URL)
+        url = "{}/require_login?came_from={}".format(self.absolute_url(), request.URL)
+        response.redirect(url, lock=1)
+        return True
+
 
 InitializeClass(OIDCPlugin)
 
@@ -280,7 +299,7 @@ classImplements(
     IOIDCPlugin,
     # IExtractionPlugin,
     # IAuthenticationPlugin,
-    # IChallengePlugin,
+    IChallengePlugin,
     # IPropertiesPlugin,
     # IRolesPlugin,
 )

--- a/src/pas/plugins/oidc/profiles/default/metadata.xml
+++ b/src/pas/plugins/oidc/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1000</version>
+  <version>1001</version>
 </metadata>

--- a/src/pas/plugins/oidc/tests/test_functional.py
+++ b/src/pas/plugins/oidc/tests/test_functional.py
@@ -69,7 +69,6 @@ class TestFunctionalPlugin(unittest.TestCase):
         # self.browser.raiseHttpErrors = False
         self.browser.followRedirects = False
         portal_url = self.portal.absolute_url()
-        plugin_url = self.portal.acl_users.oidc.absolute_url()
 
         # Try going to a page for which you need to be authenticated.
         url = portal_url + "/@@overview-controlpanel"
@@ -97,7 +96,6 @@ class TestFunctionalPlugin(unittest.TestCase):
 
         # Try going to a page for which you need to be authenticated.
         url = portal_url + "/@@overview-controlpanel"
-        quoted_url = quote(url)
         self.browser.open(url)
 
         # Since we have told the browser to not follow redirects,

--- a/src/pas/plugins/oidc/tests/test_functional.py
+++ b/src/pas/plugins/oidc/tests/test_functional.py
@@ -1,0 +1,117 @@
+from pas.plugins.oidc.testing import PAS_PLUGINS_OIDC_FUNCTIONAL_TESTING
+from plone.testing.zope import Browser
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+
+import unittest
+
+try:
+    # Python 3
+    from urllib.parse import quote
+except ImportError:
+    # Python 2
+    from urllib import quote
+
+
+class TestFunctionalPlugin(unittest.TestCase):
+
+    layer = PAS_PLUGINS_OIDC_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.browser = Browser(self.layer["app"])
+        self.browser.handleErrors = False
+
+    def test_challenge_anonymous(self):
+        self.browser.handleErrors = True
+        # self.browser.raiseHttpErrors = False
+        self.browser.followRedirects = False
+        portal_url = self.portal.absolute_url()
+        plugin_url = self.portal.acl_users.oidc.absolute_url()
+
+        # Try going to a page for which you need to be authenticated.
+        url = portal_url + "/@@overview-controlpanel"
+        quoted_url = quote(url)
+        self.browser.open(url)
+
+        # Since we have told the browser to not follow redirects,
+        # we are at the requested location.
+        self.assertEqual(self.browser.url, url)
+        # Plone wants to redirect us to the require_login page of the plugin.
+        location = self.browser.headers["location"]
+        self.assertEqual(location, plugin_url + "/require_login?came_from=" + url)
+
+        # Follow one redirect.
+        self.browser.open(location)
+        self.assertEqual(self.browser.url, location)
+        # Plone wants to redirect us to the login page of the plugin.
+        location = self.browser.headers["location"]
+        self.assertEqual(location, plugin_url + "/login?came_from=" + quoted_url)
+
+        # If we would follow the redirect, we would get a 500 Internal Server Error
+        # because the login view calls get_oauth2_client on the plugin,
+        # and we have not setup such a client in the tests.  We may need to mock
+        # some code.
+        # But the challenge plugin works: it makes sure we end up on the login view
+        # of our plugin, and not on the standard Plone login form.
+
+    def test_challenge_authenticated_manager(self):
+        self.browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(
+                SITE_OWNER_NAME,
+                SITE_OWNER_PASSWORD,
+            ),
+        )
+        self.browser.handleErrors = True
+        # self.browser.raiseHttpErrors = False
+        self.browser.followRedirects = False
+        portal_url = self.portal.absolute_url()
+        plugin_url = self.portal.acl_users.oidc.absolute_url()
+
+        # Try going to a page for which you need to be authenticated.
+        url = portal_url + "/@@overview-controlpanel"
+        self.browser.open(url)
+
+        # we are at the requested location.
+        self.assertEqual(self.browser.url, url)
+        self.assertEqual(self.browser.headers["status"], "200 OK")
+        self.assertIn("Site Setup", self.browser.contents)
+        self.assertIn("Log out", self.browser.contents)
+
+    def test_challenge_authenticated_member(self):
+        self.browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(
+                TEST_USER_NAME,
+                TEST_USER_PASSWORD,
+            ),
+        )
+        self.browser.handleErrors = True
+        # self.browser.raiseHttpErrors = False
+        self.browser.followRedirects = False
+        portal_url = self.portal.absolute_url()
+        plugin_url = self.portal.acl_users.oidc.absolute_url()
+
+        # Try going to a page for which you need to be authenticated.
+        url = portal_url + "/@@overview-controlpanel"
+        quoted_url = quote(url)
+        self.browser.open(url)
+
+        # Since we have told the browser to not follow redirects,
+        # we are at the requested location.
+        self.assertEqual(self.browser.url, url)
+        # Plone wants to redirect us to the require_login page of the plugin.
+        location = self.browser.headers["location"]
+        self.assertEqual(location, plugin_url + "/require_login?came_from=" + url)
+
+        # Follow one redirect.
+        self.browser.open(location)
+        self.assertEqual(self.browser.url, location)
+        # Plone sees that we are authenticated, but do not have sufficient privileges.
+        # The plugin does not redirect to the oidc server, because that would likely
+        # result in login loops.
+        location = self.browser.headers["location"]
+        self.assertEqual(location, portal_url + "/insufficient-privileges")

--- a/src/pas/plugins/oidc/tests/test_plugin.py
+++ b/src/pas/plugins/oidc/tests/test_plugin.py
@@ -33,3 +33,16 @@ class TestPlugin(unittest.TestCase):
         self.assertEqual(
             splitTicket(b64decode(self.response.cookies["__ac"]["value"]))[1], "bob"
         )
+
+    def test_challenge(self):
+        request_url = self.request.URL
+
+        # When the plugin makes a challenge, it must return a True value.
+        self.assertTrue(self.plugin.challenge(self.request, self.response))
+
+        # Check the response.
+        plugin_url = self.plugin.absolute_url()
+        self.assertEqual(
+            self.response.headers["location"],
+            "{}/require_login?came_from={}".format(plugin_url, request_url),
+        )


### PR DESCRIPTION
The code is mainly from [`pas.plugins.headers`](https://github.com/collective/pas.plugins.headers).
Works for me.
TODO:

- [x] add tests
- [x] add post_handler to enable the challenge plugin and put it at the top
- [x] add upgrade step to do the same
