### PR TITLE
When login view sets a cookie, return an html page with redirect in JS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 1.0a5 (unreleased)
 ------------------
 
+- When cookies are being set on the login view, return an html page that does a redirect in JavaScript.
+  When no cookies are being set, redirect to the OIDC server directly, as we always did until now.
+  This is done because mixing a redirect and a Set-Cookie header in one request may not work.
+  Fixes `issue 11 <https://github.com/collective/pas.plugins.oidc/issues/11>`_.
+  [maurits]
+
 - Update the plugin to make challenges.
   An anonymous user who visits a page for which you have to be authenticated,
   is redirected to the new require_login view on the plugin.

--- a/src/pas/plugins/oidc/browser/configure.zcml
+++ b/src/pas/plugins/oidc/browser/configure.zcml
@@ -8,6 +8,7 @@
       for="..plugins.IOIDCPlugin"
       name="login"
       class=".view.LoginView"
+      template="login_redirect.pt"
       layer="pas.plugins.oidc.interfaces.IPasPluginsOidcLayer"
       permission="zope2.View"
       />

--- a/src/pas/plugins/oidc/browser/login_redirect.pt
+++ b/src/pas/plugins/oidc/browser/login_redirect.pt
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="pas.plugins.oidc">
+<head>
+    <title i18n:translate="">Redirecting...</title>
+</head>
+<body>
+    <h1 i18n:translate="">Redirecting...</h1>
+    <p i18n:translate="description_redirecting">
+      In a moment you will be redirected to the central authentication server.
+      If you are not redirected, click the following link:
+      <a id="link" href="${view/login_url}" i18n:translate="">Go Now</a>
+    </p>
+    <script type="text/javascript">
+      setTimeout(function(){
+        document.getElementById("link").click();
+      }, 1);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
When no cookies are being set, redirect to the OIDC server directly, as we did until now. This is done because mixing a redirect and a Set-Cookie header in one request may not work. Fixes issue #11.

Note: I could have let the template inherit from the main_template, but I deliberately kept it simple, because the page tries to redirect in one millisecond anyway.

This PR branch is based upon my branch from PR #13 because I want to test the two together in a client project. But the PR is valid on its own as well, and should apply cleanly on master. I can make a separate branch if you want.

Here is a screenshot of the network tab so you can see what redirects are done with this:

![Screenshot 2023-01-24 at 14 49 32](https://user-images.githubusercontent.com/210587/214314285-b6bb078a-c50d-4b5b-a673-67fbe70bb507.png)

Before this, I had already created a page Test, kept it private, but shared it with authenticated users. Now as anonymous user:

- I visit the Plone homepage. Plone is on port 9350.
- I go to the Test page. I am not allowed to see this.
- I get redirected to `acl_users/oidc/require_login` (this is done by the code from PR #13). This sees that I am anonymous.
- I get redirected to `acl_users/oidc/login`. This sets a cookie and it returns an html page with JavaScript.
- After a brief pause, the JavaScript opens the auth page of the KeyCloak server that runs at port 8080. I fill in my user name and password there.
- This lands me on the `authenticate` page on KeyCloak.
- This redirects me back to `acl_users/oidc/callback`.
- This finally means I am authenticated and I end up on the Test page.

The important thing here is that the `came_from` that is saved in the session (encoded in the session cookie in my case) now works: I automatically end up on the Test page, instead of the homepage.
