### PR TITLE
Implement minimal group provisioning

### DIFF
--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -185,7 +185,7 @@ class OIDCPlugin(BasePlugin):
                 # if time.time() > user.getProperty(LAST_UPDATE_USER_PROPERTY_KEY) + config.get(autoUpdateUserPropertiesIntervalKey, 0):
                 with safe_write(self.REQUEST):
                     self._updateUserProperties(user, userinfo)
-        if self.getProperty("create_groups") and "groups" in userinfo:
+        if self.getProperty("create_groups") and isinstance(userinfo.get("groups"), list):
             with safe_write(self.REQUEST):
                 oidc = self.getId()
                 groups = user.getGroups()

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -68,6 +68,7 @@ class OIDCPlugin(BasePlugin):
     create_restapi_ticket = False
     create_user = True
     create_groups = False
+    user_property_as_groupid = "groups"
     scope = ("profile", "email", "phone")
     use_pkce = False
     use_modified_openid_schema = False
@@ -94,7 +95,13 @@ class OIDCPlugin(BasePlugin):
             id="create_groups",
             type="boolean",
             mode="w",
-            label="Greate groups / update group memberships",
+            label="Create groups / update group memberships",
+        ),
+        dict(
+            id="user_property_as_groupid",
+            type="string",
+            mode="w",
+            label="User info property used as groupid, default 'groups'",
         ),
         dict(
             id="create_ticket",
@@ -185,25 +192,39 @@ class OIDCPlugin(BasePlugin):
                 # if time.time() > user.getProperty(LAST_UPDATE_USER_PROPERTY_KEY) + config.get(autoUpdateUserPropertiesIntervalKey, 0):
                 with safe_write(self.REQUEST):
                     self._updateUserProperties(user, userinfo)
-        if self.getProperty("create_groups") and isinstance(userinfo.get("groups"), list):
-            with safe_write(self.REQUEST):
-                oidc = self.getId()
-                groups = user.getGroups()
-                # Remove group memberships
-                for gid in groups:
-                    group = api.group.get(gid)
-                    is_managed = group.getProperty("type") == oidc.upper()
-                    if is_managed and gid not in userinfo["groups"]:
-                        api.group.remove_user(group=group, username=user_id)
-                # Add group memberships
-                for gid in userinfo["groups"]:
-                    if gid not in groups:
-                        group = api.group.get(gid) or api.group.create(gid, title=gid)
-                        # Tag managed groups with "type" of plugin id
-                        if not group.getTool().hasProperty("type"):
-                            group.getTool()._setProperty("type", "", "string")
-                        group.setGroupProperties({"type": oidc.upper()})
-                        api.group.add_user(group=group, username=user_id)
+
+        if self.getProperty("create_groups"):
+            groupid_property = self.getProperty("user_property_as_groupid")
+            groupid = userinfo.get(groupid_property, None)
+            if isinstance(groupid, str):
+                groupid = [groupid]
+
+            if isinstance(groupid, list):
+                with safe_write(self.REQUEST):
+                    oidc = self.getId()
+                    groups = user.getGroups()
+                    # Remove group memberships
+                    for gid in groups:
+                        group = api.group.get(gid)
+                        is_managed = group.getProperty("type") == oidc.upper()
+                        if is_managed and gid not in groupid:
+                            api.group.remove_user(
+                                group=group, username=user_id
+                            )
+                    # Add group memberships
+                    for gid in groupid:
+                        if gid not in groups:
+                            group = api.group.get(gid) or api.group.create(
+                                gid, title=gid
+                            )
+                            # Tag managed groups with "type" of plugin id
+                            if not group.getTool().hasProperty("type"):
+                                group.getTool()._setProperty(
+                                    "type", "", "string"
+                                )
+                            group.setGroupProperties({"type": oidc.upper()})
+                            api.group.add_user(group=group, username=user_id)
+
         if user and self.getProperty("create_ticket"):
             self._setupTicket(user_id)
         if user and self.getProperty("create_restapi_ticket"):

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -24,6 +24,7 @@ from zope.interface import Interface
 import itertools
 import logging
 import string
+import plone.api as api
 
 try:
     # Plone 6.0+
@@ -66,6 +67,7 @@ class OIDCPlugin(BasePlugin):
     create_ticket = True
     create_restapi_ticket = False
     create_user = True
+    create_groups = False
     scope = ("profile", "email", "phone")
     use_pkce = False
     use_modified_openid_schema = False
@@ -87,6 +89,12 @@ class OIDCPlugin(BasePlugin):
             type="boolean",
             mode="w",
             label="Create user / update user properties",
+        ),
+        dict(
+            id="create_groups",
+            type="boolean",
+            mode="w",
+            label="Greate groups / update group memberships",
         ),
         dict(
             id="create_ticket",
@@ -177,6 +185,25 @@ class OIDCPlugin(BasePlugin):
                 # if time.time() > user.getProperty(LAST_UPDATE_USER_PROPERTY_KEY) + config.get(autoUpdateUserPropertiesIntervalKey, 0):
                 with safe_write(self.REQUEST):
                     self._updateUserProperties(user, userinfo)
+        if self.getProperty("create_groups") and "groups" in userinfo:
+            with safe_write(self.REQUEST):
+                oidc = self.getId()
+                groups = user.getGroups()
+                # Remove group memberships
+                for gid in groups:
+                    group = api.group.get(gid)
+                    is_managed = group.getProperty("type") == oidc.upper()
+                    if is_managed and gid not in userinfo["groups"]:
+                        api.group.remove_user(group=group, username=user_id)
+                # Add group memberships
+                for gid in userinfo["groups"]:
+                    if gid not in groups:
+                        group = api.group.get(gid) or api.group.create(gid, title=gid)
+                        # Tag managed groups with "type" of plugin id
+                        if not group.getTool().hasProperty("type"):
+                            group.getTool()._setProperty("type", "", "string")
+                        group.setGroupProperties({"type": oidc.upper()})
+                        api.group.add_user(group=group, username=user_id)
         if user and self.getProperty("create_ticket"):
             self._setupTicket(user_id)
         if user and self.getProperty("create_restapi_ticket"):


### PR DESCRIPTION
We'd like to implement provisioning of groups directly from id token / user info, if it includes list of group ids:

1. create missing groups
2. tag groups to be "managed" when they receive members from plugin
3. remove member from tagged group when user info no longer includes membership

This is opinionated approach, so I'd request for comments, before polishing with requested changes, changelog and tests.

For example, should there be more granular configuration? Separate toggles for group creation and membership management? Customizable user info attribute for groups list? Customizable group property used in tagging? Something else?