### PR TITLE
use configurable property name to assign groups

### DIFF
--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -68,6 +68,7 @@ class OIDCPlugin(BasePlugin):
     create_restapi_ticket = False
     create_user = True
     create_groups = False
+    user_property_as_groupid = "groups"
     scope = ("profile", "email", "phone")
     use_pkce = False
     use_modified_openid_schema = False
@@ -94,7 +95,13 @@ class OIDCPlugin(BasePlugin):
             id="create_groups",
             type="boolean",
             mode="w",
-            label="Greate groups / update group memberships",
+            label="Create groups / update group memberships",
+        ),
+        dict(
+            id="user_property_as_groupid",
+            type="string",
+            mode="w",
+            label="User info property used as groupid, default 'groups'",
         ),
         dict(
             id="create_ticket",
@@ -185,25 +192,39 @@ class OIDCPlugin(BasePlugin):
                 # if time.time() > user.getProperty(LAST_UPDATE_USER_PROPERTY_KEY) + config.get(autoUpdateUserPropertiesIntervalKey, 0):
                 with safe_write(self.REQUEST):
                     self._updateUserProperties(user, userinfo)
-        if self.getProperty("create_groups") and isinstance(userinfo.get("groups"), list):
-            with safe_write(self.REQUEST):
-                oidc = self.getId()
-                groups = user.getGroups()
-                # Remove group memberships
-                for gid in groups:
-                    group = api.group.get(gid)
-                    is_managed = group.getProperty("type") == oidc.upper()
-                    if is_managed and gid not in userinfo["groups"]:
-                        api.group.remove_user(group=group, username=user_id)
-                # Add group memberships
-                for gid in userinfo["groups"]:
-                    if gid not in groups:
-                        group = api.group.get(gid) or api.group.create(gid, title=gid)
-                        # Tag managed groups with "type" of plugin id
-                        if not group.getTool().hasProperty("type"):
-                            group.getTool()._setProperty("type", "", "string")
-                        group.setGroupProperties({"type": oidc.upper()})
-                        api.group.add_user(group=group, username=user_id)
+
+        if self.getProperty("create_groups"):
+            groupid_property = self.getProperty("user_property_as_groupid")
+            groupid = userinfo.get(groupid_property, None)
+            if isinstance(groupid, str):
+                groupid = [groupid]
+
+            if isinstance(groupid, list):
+                with safe_write(self.REQUEST):
+                    oidc = self.getId()
+                    groups = user.getGroups()
+                    # Remove group memberships
+                    for gid in groups:
+                        group = api.group.get(gid)
+                        is_managed = group.getProperty("type") == oidc.upper()
+                        if is_managed and gid not in groupid:
+                            api.group.remove_user(
+                                group=group, username=user_id
+                            )
+                    # Add group memberships
+                    for gid in groupid:
+                        if gid not in groups:
+                            group = api.group.get(gid) or api.group.create(
+                                gid, title=gid
+                            )
+                            # Tag managed groups with "type" of plugin id
+                            if not group.getTool().hasProperty("type"):
+                                group.getTool()._setProperty(
+                                    "type", "", "string"
+                                )
+                            group.setGroupProperties({"type": oidc.upper()})
+                            api.group.add_user(group=group, username=user_id)
+
         if user and self.getProperty("create_ticket"):
             self._setupTicket(user_id)
         if user and self.getProperty("create_restapi_ticket"):


### PR DESCRIPTION
@datakurre these changes allow to configure the property to be used as group source, and they also allow this value to be a simple string.

With these changes the configuration I used to auto-assign Manager rights to users logged in using our specific Google Workspace account is much easier than the one I explained in the blog post!

