### PR TITLE
Several fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 1.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Drop python 2.7 and Plone 4 support
+  [erral]
 
 1.0a5 (2023-04-05)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Framework :: Plone :: Addon",
         "Framework :: Plone :: 5.2",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = "\n\n".join(
 
 setup(
     name="pas.plugins.oidc",
-    version='1.0a6.dev0',
+    version="1.0a6.dev0",
     description="An add-on for Plone",
     long_description=long_description,
     # Get more from https://pypi.org/classifiers/
@@ -51,7 +51,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    python_requires=">=3.7"
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.7"
+    python_requires=">=3.7",
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         # -*- Extra requirements: -*-
         "z3c.jbot",
         "plone.api>=1.8.4",
-        "plone.restapi",
         # 'oidcrp',
         # "oic<1; python_version < 3",
         "oic",

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -253,7 +253,7 @@ class CallbackView(BrowserView):
         )
 
         if isinstance(resp, AccessTokenResponse):
-            # If it’s an AccessTokenResponse the information in the response will be stored in the
+            # If it's an AccessTokenResponse the information in the response will be stored in the
             # client instance with state as the key for future use.
             if client.userinfo_endpoint:
                 # https://openid.net/specs/openid-connect-core-1_0.html#UserInfo

--- a/src/pas/plugins/oidc/testing.py
+++ b/src/pas/plugins/oidc/testing.py
@@ -21,9 +21,6 @@ class PasPluginsOidcLayer(PloneSandboxLayer):
         # Load any other ZCML that is required for your tests.
         # The z3c.autoinclude feature is disabled in the Plone fixture base
         # layer.
-        import plone.restapi
-
-        self.loadZCML(package=plone.restapi)
         self.loadZCML(package=pas.plugins.oidc)
 
     def setUpPloneSite(self, portal):


### PR DESCRIPTION
- Remove plone.restapi dependency as we are not using it 
- Do not claim to support python 2.7. Our dependency oic only supports python 2 in its version 0.15.1 (current version is 1.5.0). I have been trying to install this plugin in an old Plone 4.3 and it's really hard to get all the dependencies installed, so we better move forward and deprecate python 2