### PR TITLE
Allow dicts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 1.0a7 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Allow dict instances to hold userinfo
+  [erral]
 
 1.0a6 (2023-07-20)
 ------------------

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -272,7 +272,7 @@ class CallbackView(BrowserView):
 
             # userinfo in an instance of OpenIDSchema or ErrorResponse
             # It could also be dict, if there is no userinfo_endpoint
-            if isinstance(userinfo, (OpenIDSchema, dict)):
+            if userinfo and isinstance(userinfo, (OpenIDSchema, dict)):
                 self.context.rememberIdentity(userinfo)
                 self.request.response.setHeader(
                     "Cache-Control", "no-cache, must-revalidate"

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -271,7 +271,8 @@ class CallbackView(BrowserView):
                 userinfo = resp.to_dict().get("id_token", {})
 
             # userinfo in an instance of OpenIDSchema or ErrorResponse
-            if isinstance(userinfo, OpenIDSchema):
+            # It could also be dict, if there is no userinfo_endpoint
+            if isinstance(userinfo, (OpenIDSchema, dict)):
                 self.context.rememberIdentity(userinfo)
                 self.request.response.setHeader(
                     "Cache-Control", "no-cache, must-revalidate"

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -143,7 +143,7 @@ class OIDCPlugin(BasePlugin):
     )
 
     def rememberIdentity(self, userinfo):
-        if not isinstance(userinfo, OpenIDSchema):
+        if not isinstance(userinfo, (OpenIDSchema, dict)):
             raise AssertionError("userinfo should be an OpenIDSchema but is {}".format(type(userinfo)))
         # sub: machine-readable identifier of the user at this server;
         #      this value is guaranteed to be unique per user, stable over time,


### PR DESCRIPTION
When using an OpenID Connect provider that does not have a UserInfo endpoint, the user information should be decoded from the `id_token` key of the authorization request.

In such cases, the value is not an instance of `OpenIdSchema` so the login process would fail here.

That's what happens when using EU Login for instance.

With these changes, we modify how the result is checked and we also allow `dict`s.

We also check userinfo not being empty, to avoid further errors in the `rememberIdentity` method.