### PR TITLE
Add "Sign in with Apple" extra configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ When using this plugin with a [Volto frontend](https://6.docs.plone.org/volto/in
 
 Also, on the OpenID provider, configure the Redirect URL as **`<Path to your Plone site>`/login_oidc/oidc**.
 
+
 #### Classic UI
 
-When using this plugin with _Plone 6 Classic UI_ the standard URLs used for login (`http://localhost:8080/Plone/login`) and logout (`http://localhost:8080/Plone/logout`)
+When using this plugin with *Plone 6 Classic UI* the standard URLs used for login (`http://localhost:8080/Plone/login`) and logout (`http://localhost:8080/Plone/logout`)
 will not trigger the usage of the plugin.
 
 To login into a site using the OIDC provider, you will need to change those login URLs to the following:
@@ -117,8 +118,8 @@ This command will use the [`docker-compose.yml`](./tests/docker-compose.yml) fil
 
 After start up, Keycloak will be accessible on [http://127.0.0.1:8180](http://127.0.0.1:8180), and you can manage it with the following credentials:
 
-- **username**: admin
-- **password**: admin
+* **username**: admin
+* **password**: admin
 
 #### Realms
 
@@ -126,13 +127,13 @@ There are two realms configured `plone` and `plone-test`. The later is used in a
 
 The `plone` realm ships with an user that has the following credentials:
 
-- username: **user**
-- password: **12345678**
+* username: **user**
+* password: **12345678**
 
 And, to configure the oidc plugins, please use:
 
-- client id: **plone**
-- client secret: **12345678**
+* client id: **plone**
+* client secret: **12345678**
 
 #### Stop Keycloak
 
@@ -151,18 +152,18 @@ will not work.
 
 So, this is the way it works:
 
-- With legacy `redirect_uri` parameter enabled in Keycloak, the plugin works in default mode.
-- With legacy `redirect_uri` parameter enabled in Keycloak, the plugin also works with legacy mode.
-- With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin works in default mode.
-- With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin does NOT work with legacy mode.
+* With legacy `redirect_uri` parameter enabled in Keycloak, the plugin works in default mode.
+* With legacy `redirect_uri` parameter enabled in Keycloak, the plugin also works with legacy mode.
+* With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin works in default mode.
+* With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin does NOT work with legacy mode.
 
 So, for Keycloak, it does not matter if we use the default or legacy mode if the Keycloak runs in legacy mode.
 
 _Notes:_
 
-- If legacy `redirect_uri` parameter is disabled in Keycloak, this is the default since version 18 of Keycloak according
+* If legacy `redirect_uri` parameter is disabled in Keycloak, this is the default since version 18 of Keycloak according
   to this comment in _Starck Overflow_: https://stackoverflow.com/a/72142887.
-- The plugin will work only if the `Use deprecated redirect_uri for logout url(/Plone/acl_users/oidc/logout)`
+* The plugin will work only if the `Use deprecated redirect_uri for logout url(/Plone/acl_users/oidc/logout)`
   option is un-checked at the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm.
 
 #### Additional Documentation
@@ -172,20 +173,20 @@ Specifically, here we will use a Docker image, so follow the instructions on how
 
 #### Setup Plone as a client
 
-- Make sure **pas.plugins.oidc** is installed.
-- Start Plone and create a Plone site with id Plone.
-- In the Add-ons control panel, install `pas.plugins.oidc`.
-- In the ZMI go to the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm
-- Set these properties:
-  - `OIDC/Oauth2 Issuer`: http://127.0.0.1:8081/realms/plone/
-  - `Client ID`: _plone_ (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
-  - `Client secret`: _12345678_ (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
-  - `Use deprecated redirect_uri for logout url` checked. Use this if you need to run old versions of Keycloak.
-  - `Open ID scopes to request to the server`: this depends on which version of Keycloak you are using, and which scopes are available there.
+* Make sure **pas.plugins.oidc** is installed.
+* Start Plone and create a Plone site with id Plone.
+* In the Add-ons control panel, install `pas.plugins.oidc`.
+* In the ZMI go to the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm
+* Set these properties:
+  * `OIDC/Oauth2 Issuer`: http://127.0.0.1:8081/realms/plone/
+  * `Client ID`: _plone_ (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
+  * `Client secret`: _12345678_ (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
+  * `Use deprecated redirect_uri for logout url` checked. Use this if you need to run old versions of Keycloak.
+  * `Open ID scopes to request to the server`: this depends on which version of Keycloak you are using, and which scopes are available there.
     In recent Keycloak versions, you _must_ include `openid` as scope.
     Suggestion is to use `openid` and `profile`.
-  - **Tip:** Leave the rest at the defaults, unless you know what you are doing.
-  - Click `Save`.
+  * **Tip:** Leave the rest at the defaults, unless you know what you are doing.
+  * Click `Save`.
 
 **Plone is ready done configured!**
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ removes most cookies to improve anonymous caching.
 The solution is to make sure the `__ac_session` cookie is added to the `cookie-pass` option.
 Check what the current default is in the buildout recipe, and update it:
 
+
 ## Contribute
 
 - Issue Tracker: https://github.com/collective/pas.plugins.oidc/issues
@@ -304,8 +305,8 @@ There are two realms configured `plone` and `plone-test`. The later is used in a
 
 The `plone` realm ships with an user that has the following credentials:
 
-- username: **user**
-- password: **12345678**
+* username: **user**
+* password: **12345678**
 
 To stop a running `Keycloak` (needed when running tests), use:
 
@@ -349,7 +350,7 @@ Run tests named `TestServiceOIDCPost`:
 
 ## References
 
-- Blog post: https://www.codesyntax.com/en/blog/log-in-in-plone-using-your-google-workspace-account
+* Blog post: https://www.codesyntax.com/en/blog/log-in-in-plone-using-your-google-workspace-account
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![PyPI - License](https://img.shields.io/pypi/l/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 [![PyPI - Status](https://img.shields.io/pypi/status/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 
-
 [![PyPI - Plone Versions](https://img.shields.io/pypi/frameworkversions/plone/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 
 [![Meta](https://github.com/collective/pas.plugins.oidc/actions/workflows/meta.yml/badge.svg)](https://github.com/collective/pas.plugins.oidc/actions/workflows/meta.yml)
@@ -22,6 +21,7 @@
 </div>
 
 ## Intro
+
 This is a Plone authentication plugin for OpenID Connect.
 OAuth 2.0 should work as well because OpenID Connect is built on top of this protocol.
 
@@ -30,47 +30,45 @@ OAuth 2.0 should work as well because OpenID Connect is built on top of this pro
 - PAS plugin, although currently no interfaces are activated.
 - Three browser views for this PAS plugin, which are the main interaction with the outside world.
 
-
 ## Installation
 
 This package supports Plone sites using Volto and ClassicUI.
 
 For proper Volto support, the requirements are:
 
-* plone.restapi >= 8.34.0
-* Volto >= 16.10.0
+- plone.restapi >= 8.34.0
+- Volto >= 16.10.0
 
 Add **pas.plugins.oidc** to the Plone installation using `pip`:
 
-``bash
+`bash
 pip install pas.plugins.oidc
-``
+`
 
 ### Requirements
 
-As of version 2.* of this package the minimum requirements are Plone 6.0 and python 3.8.
+As of version 2.\* of this package the minimum requirements are Plone 6.0 and python 3.8.
 
 ### Warning
 
 Pay attention to the customization of `User info property used as userid` field, with the wrong configuration it's easy to impersonate another user.
 
-
 ## Configure the plugin
 
-* Go to the Add-ons control panel and install `pas.plugins.oidc`.
-* In the ZMI go to the plugin properties at `http://localhost:8080/Plone/acl_users/oidc/manage_propertiesForm`
-* Configure the properties with the data obtained from your provider:
-  * `OIDC/Oauth2 Issuer`
-  * `Client ID`
-  * `Client secret`
-  * `redirect_uris`: this needs to match the **public URL** where the user will be redirected after the login flow is completed. It needs to include
+- Go to the Add-ons control panel and install `pas.plugins.oidc`.
+- In the ZMI go to the plugin properties at `http://localhost:8080/Plone/acl_users/oidc/manage_propertiesForm`
+- Configure the properties with the data obtained from your provider:
+  - `OIDC/Oauth2 Issuer`
+  - `Client ID`
+  - `Client secret`
+  - `redirect_uris`: this needs to match the **public URL** where the user will be redirected after the login flow is completed. It needs to include
     the `/Plone/acl_users/oidc/callback` part. When using Volto you need to expose Plone somehow to have the login process finish correctly.
-  * `Use Zope session data manager`: see the section below about the usage of session.
-  * `Create user / update user properties`: when selected the user data in Plone will be updated with the data coming from the OIDC provider.
-  * `Create authentication __ac ticket`: when selected the user will be allowed to act as a logged-in user in Plone.
-  * `Create authentication auth_token (Volto/REST API) ticket`: when selected the user will be allowed to act as a logged-in user in the Volto frontend.
-  * `Open ID scopes to request to the server`: information requested to the OIDC provider. Leave it as it is or modify it according to your provider's information.
-  * `Use PKCE`: when enabled uses [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) when requesting authentication from the provider.
+  - `Use Zope session data manager`: see the section below about the usage of session.
+  - `Create user / update user properties`: when selected the user data in Plone will be updated with the data coming from the OIDC provider.
+  - `Create authentication __ac ticket`: when selected the user will be allowed to act as a logged-in user in Plone.
+  - `Create authentication auth_token (Volto/REST API) ticket`: when selected the user will be allowed to act as a logged-in user in the Volto frontend.
+  - `Open ID scopes to request to the server`: information requested to the OIDC provider. Leave it as it is or modify it according to your provider's information.
+  - `Use PKCE`: when enabled uses [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) when requesting authentication from the provider.
 
 ### Login and Logout URLs
 
@@ -78,27 +76,26 @@ Pay attention to the customization of `User info property used as userid` field,
 
 When using this plugin with a [Volto frontend](https://6.docs.plone.org/volto/index.html), please install [@plone-collective/volto-authomatic](https://github.com/collective/volto-authomatic) add-on on your frontend project.
 
-* **Login URL**: `<Path to your Plone site>`/login
-* **Logout URL**: `<Path to your Plone site>`/logout
+- **Login URL**: `<Path to your Plone site>`/login
+- **Logout URL**: `<Path to your Plone site>`/logout
 
 Also, on the OpenID provider, configure the Redirect URL as **`<Path to your Plone site>`/login_oidc/oidc**.
 
-
 #### Classic UI
 
-When using this plugin with *Plone 6 Classic UI* the standard URLs used for login (`http://localhost:8080/Plone/login`) and logout (`http://localhost:8080/Plone/logout`)
+When using this plugin with _Plone 6 Classic UI_ the standard URLs used for login (`http://localhost:8080/Plone/login`) and logout (`http://localhost:8080/Plone/logout`)
 will not trigger the usage of the plugin.
 
 To login into a site using the OIDC provider, you will need to change those login URLs to the following:
 
-* **Login URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/login
-* **Logout URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/logout
+- **Login URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/login
+- **Logout URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/logout
 
-*Where:*
+_Where:_
 
-  * `Plone Site Id`: is the id you gave to the Plone site when you created it. It is usually `Plone` but may vary. It is the last part of the URL when you browse Plone directly without using any proxy server, ex. `http://localhost:8080/Plone+` -> `Plone`.
+- `Plone Site Id`: is the id you gave to the Plone site when you created it. It is usually `Plone` but may vary. It is the last part of the URL when you browse Plone directly without using any proxy server, ex. `http://localhost:8080/Plone+` -> `Plone`.
 
-  * `oidc pas plugin id`: is the id you gave to the OIDC plugin when you created it inside the Plone PAS administration panel. If you just used the default configuration and installed this plugin using Plone's Add-on Control Panel, this id will be `oidc`.
+- `oidc pas plugin id`: is the id you gave to the OIDC plugin when you created it inside the Plone PAS administration panel. If you just used the default configuration and installed this plugin using Plone's Add-on Control Panel, this id will be `oidc`.
 
 ### Example setup with Keycloak
 
@@ -118,8 +115,8 @@ This command will use the [`docker-compose.yml`](./tests/docker-compose.yml) fil
 
 After start up, Keycloak will be accessible on [http://127.0.0.1:8180](http://127.0.0.1:8180), and you can manage it with the following credentials:
 
-* **username**: admin
-* **password**: admin
+- **username**: admin
+- **password**: admin
 
 #### Realms
 
@@ -127,13 +124,13 @@ There are two realms configured `plone` and `plone-test`. The later is used in a
 
 The `plone` realm ships with an user that has the following credentials:
 
-* username: **user**
-* password: **12345678**
+- username: **user**
+- password: **12345678**
 
 And, to configure the oidc plugins, please use:
 
-* client id: **plone**
-* client secret: **12345678**
+- client id: **plone**
+- client secret: **12345678**
 
 #### Stop Keycloak
 
@@ -151,18 +148,19 @@ parameter enabled also. The problem is that if the deprecated parameter is enabl
 will not work.
 
 So, this is the way it works:
-* With legacy `redirect_uri` parameter enabled in Keycloak, the plugin works in default mode.
-* With legacy `redirect_uri` parameter enabled in Keycloak, the plugin also works with legacy mode.
-* With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin works in default mode.
-* With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin does NOT work with legacy mode.
+
+- With legacy `redirect_uri` parameter enabled in Keycloak, the plugin works in default mode.
+- With legacy `redirect_uri` parameter enabled in Keycloak, the plugin also works with legacy mode.
+- With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin works in default mode.
+- With legacy `redirect_uri` parameter disabled in Keycloak (default after version 18), the plugin does NOT work with legacy mode.
 
 So, for Keycloak, it does not matter if we use the default or legacy mode if the Keycloak runs in legacy mode.
 
-*Notes:*
+_Notes:_
 
-* If legacy `redirect_uri` parameter is disabled in Keycloak, this is the default since version 18 of Keycloak according
-  to this comment in *Starck Overflow*: https://stackoverflow.com/a/72142887.
-* The plugin will work only if the `Use deprecated redirect_uri for logout url(/Plone/acl_users/oidc/logout)`
+- If legacy `redirect_uri` parameter is disabled in Keycloak, this is the default since version 18 of Keycloak according
+  to this comment in _Starck Overflow_: https://stackoverflow.com/a/72142887.
+- The plugin will work only if the `Use deprecated redirect_uri for logout url(/Plone/acl_users/oidc/logout)`
   option is un-checked at the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm.
 
 #### Additional Documentation
@@ -172,20 +170,20 @@ Specifically, here we will use a Docker image, so follow the instructions on how
 
 #### Setup Plone as a client
 
-* Make sure **pas.plugins.oidc** is installed.
-* Start Plone and create a Plone site with id Plone.
-* In the Add-ons control panel, install `pas.plugins.oidc`.
-* In the ZMI go to the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm
-* Set these properties:
-  * `OIDC/Oauth2 Issuer`: http://127.0.0.1:8081/realms/plone/
-  * `Client ID`: *plone* (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
-  * `Client secret`: *12345678* (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
-  * `Use deprecated redirect_uri for logout url` checked. Use this if you need to run old versions of Keycloak.
-  * `Open ID scopes to request to the server`: this depends on which version of Keycloak you are using, and which scopes are available there.
-    In recent Keycloak versions, you *must* include `openid` as scope.
+- Make sure **pas.plugins.oidc** is installed.
+- Start Plone and create a Plone site with id Plone.
+- In the Add-ons control panel, install `pas.plugins.oidc`.
+- In the ZMI go to the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm
+- Set these properties:
+  - `OIDC/Oauth2 Issuer`: http://127.0.0.1:8081/realms/plone/
+  - `Client ID`: _plone_ (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
+  - `Client secret`: _12345678_ (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
+  - `Use deprecated redirect_uri for logout url` checked. Use this if you need to run old versions of Keycloak.
+  - `Open ID scopes to request to the server`: this depends on which version of Keycloak you are using, and which scopes are available there.
+    In recent Keycloak versions, you _must_ include `openid` as scope.
     Suggestion is to use `openid` and `profile`.
-  *  **Tip:** Leave the rest at the defaults, unless you know what you are doing.
-  * Click `Save`.
+  - **Tip:** Leave the rest at the defaults, unless you know what you are doing.
+  - Click `Save`.
 
 **Plone is ready done configured!**
 
@@ -200,7 +198,7 @@ Currently, the Plone login form is unchanged.
 
 Instead, for testing go to the login page of the plugin: http://localhost:8081/Plone/acl_users/oidc/login,
 this will take you to Keycloak to login, and then return. You should now be logged in to Plone, and see the
-*full name* and *email*, if you have set this in Keycloak.
+_full name_ and _email_, if you have set this in Keycloak.
 
 #### Logout
 
@@ -209,6 +207,31 @@ Currently, the Plone logout form is unchanged.
 
 Instead, for testing go to the logout page of the plugin: http://localhost:8081/Plone/acl_users/oidc/logout,
 this will take you to Keycloak to logout, and then return to the post-logout redirect URL.
+
+### Configuration example for Sign in with Apple
+
+[Sign in with Apple](https://developer.apple.com/sign-in-with-apple/) is a way to delegate user authentication on Apple, so all Apple users can sign in in your site seamesly.
+
+But this means that you will need to do some extra steps on the Apple side in order to get your site correctly configured.
+
+1. Register an application
+
+Go to the Apple Developer Portal and create a new App ID in the [Certificates, Identifiers and Profiles](https://developer.apple.com/account/resources/identifiers/list/bundleId) section.
+
+2. Create a Service ID
+
+In the same page, create a new Service ID. The identifier you will add here will be the client_id to be used when configuring the login process. Use the reverse-domain-name style notation to create this id, something like: com.yourcompany.yoursite. Tick the _Sign in with Apple_ option. Click on _Configure_ next to the option and set your application domain and the callback url. You must enter an _https_ URL.
+
+3. Create a Private key
+
+Choose Keys on the side tab, select "Sign in with Apple" and click _Configure_. You will need to select the App Id created on the first step and download your private key, that will be shown just once.
+
+Now you have all the required items to configure this plugin:
+
+- client_id: the service id you created
+- client_secret: the value of the private key downloaded in the last step. Open the file with a text editor of your choice, remove the ----PRIVATE KEY BEGIN---- and ----PRIVATE KEY END---- markers and any new line.
+- Apple consumer team: this is your id in Apple. You can find in in the top right part of the site when logged in in the Apple developer portal
+- Apple consumer id key: it is shown in the private you created in the last step.
 
 ## Technical Decisions
 
@@ -242,7 +265,6 @@ removes most cookies to improve anonymous caching.
 
 The solution is to make sure the `__ac_session` cookie is added to the `cookie-pass` option.
 Check what the current default is in the buildout recipe, and update it:
-
 
 ## Contribute
 
@@ -279,8 +301,8 @@ There are two realms configured `plone` and `plone-test`. The later is used in a
 
 The `plone` realm ships with an user that has the following credentials:
 
-* username: **user**
-* password: **12345678**
+- username: **user**
+- password: **12345678**
 
 To stop a running `Keycloak` (needed when running tests), use:
 
@@ -324,7 +346,7 @@ Run tests named `TestServiceOIDCPost`:
 
 ## References
 
-* Blog post: https://www.codesyntax.com/en/blog/log-in-in-plone-using-your-google-workspace-account
+- Blog post: https://www.codesyntax.com/en/blog/log-in-in-plone-using-your-google-workspace-account
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ So, this is the way it works:
 
 So, for Keycloak, it does not matter if we use the default or legacy mode if the Keycloak runs in legacy mode.
 
-_Notes:_
+*Notes:*
 
 * If legacy `redirect_uri` parameter is disabled in Keycloak, this is the default since version 18 of Keycloak according
-  to this comment in _Starck Overflow_: https://stackoverflow.com/a/72142887.
+  to this comment in *Stack Overflow*: https://stackoverflow.com/a/72142887.
 * The plugin will work only if the `Use deprecated redirect_uri for logout url(/Plone/acl_users/oidc/logout)`
   option is un-checked at the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm.
 
@@ -179,11 +179,11 @@ Specifically, here we will use a Docker image, so follow the instructions on how
 * In the ZMI go to the plugin properties at http://localhost:8081/Plone/acl_users/oidc/manage_propertiesForm
 * Set these properties:
   * `OIDC/Oauth2 Issuer`: http://127.0.0.1:8081/realms/plone/
-  * `Client ID`: _plone_ (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
-  * `Client secret`: _12345678_ (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
+  * `Client ID`: *plone* (**Warning:** This property must match the `Client ID` you have set in Keycloak.)
+  * `Client secret`: *12345678* (**Warning:** This property must match the `Client secret` you have get in Keycloak.)
   * `Use deprecated redirect_uri for logout url` checked. Use this if you need to run old versions of Keycloak.
   * `Open ID scopes to request to the server`: this depends on which version of Keycloak you are using, and which scopes are available there.
-    In recent Keycloak versions, you _must_ include `openid` as scope.
+    In recent Keycloak versions, you *must* include `openid` as scope.
     Suggestion is to use `openid` and `profile`.
   * **Tip:** Leave the rest at the defaults, unless you know what you are doing.
   * Click `Save`.
@@ -199,9 +199,9 @@ See this screenshot:
 Go to the other browser, or logout as admin from [Keycloak Admin Console](http://localhost:8080/admin).
 Currently, the Plone login form is unchanged.
 
-Instead, for testing go to the login page of the plugin: http://localhost:8081/Plone/acl*users/oidc/login,
+Instead, for testing go to the login page of the plugin: http://localhost:8081/Plone/acl_users/oidc/login,
 this will take you to Keycloak to login, and then return. You should now be logged in to Plone, and see the
-\_full name* and _email_, if you have set this in Keycloak.
+*full name* and *email*, if you have set this in Keycloak.
 
 #### Logout
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![PyPI - License](https://img.shields.io/pypi/l/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 [![PyPI - Status](https://img.shields.io/pypi/status/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 
+
 [![PyPI - Plone Versions](https://img.shields.io/pypi/frameworkversions/plone/pas.plugins.oidc)](https://pypi.org/project/pas.plugins.oidc/)
 
 [![Meta](https://github.com/collective/pas.plugins.oidc/actions/workflows/meta.yml/badge.svg)](https://github.com/collective/pas.plugins.oidc/actions/workflows/meta.yml)
@@ -21,7 +22,6 @@
 </div>
 
 ## Intro
-
 This is a Plone authentication plugin for OpenID Connect.
 OAuth 2.0 should work as well because OpenID Connect is built on top of this protocol.
 
@@ -30,45 +30,47 @@ OAuth 2.0 should work as well because OpenID Connect is built on top of this pro
 - PAS plugin, although currently no interfaces are activated.
 - Three browser views for this PAS plugin, which are the main interaction with the outside world.
 
+
 ## Installation
 
 This package supports Plone sites using Volto and ClassicUI.
 
 For proper Volto support, the requirements are:
 
-- plone.restapi >= 8.34.0
-- Volto >= 16.10.0
+* plone.restapi >= 8.34.0
+* Volto >= 16.10.0
 
 Add **pas.plugins.oidc** to the Plone installation using `pip`:
 
-`bash
+``bash
 pip install pas.plugins.oidc
-`
+``
 
 ### Requirements
 
-As of version 2.\* of this package the minimum requirements are Plone 6.0 and python 3.8.
+As of version 2.* of this package the minimum requirements are Plone 6.0 and python 3.8.
 
 ### Warning
 
 Pay attention to the customization of `User info property used as userid` field, with the wrong configuration it's easy to impersonate another user.
 
+
 ## Configure the plugin
 
-- Go to the Add-ons control panel and install `pas.plugins.oidc`.
-- In the ZMI go to the plugin properties at `http://localhost:8080/Plone/acl_users/oidc/manage_propertiesForm`
-- Configure the properties with the data obtained from your provider:
-  - `OIDC/Oauth2 Issuer`
-  - `Client ID`
-  - `Client secret`
-  - `redirect_uris`: this needs to match the **public URL** where the user will be redirected after the login flow is completed. It needs to include
+* Go to the Add-ons control panel and install `pas.plugins.oidc`.
+* In the ZMI go to the plugin properties at `http://localhost:8080/Plone/acl_users/oidc/manage_propertiesForm`
+* Configure the properties with the data obtained from your provider:
+  * `OIDC/Oauth2 Issuer`
+  * `Client ID`
+  * `Client secret`
+  * `redirect_uris`: this needs to match the **public URL** where the user will be redirected after the login flow is completed. It needs to include
     the `/Plone/acl_users/oidc/callback` part. When using Volto you need to expose Plone somehow to have the login process finish correctly.
-  - `Use Zope session data manager`: see the section below about the usage of session.
-  - `Create user / update user properties`: when selected the user data in Plone will be updated with the data coming from the OIDC provider.
-  - `Create authentication __ac ticket`: when selected the user will be allowed to act as a logged-in user in Plone.
-  - `Create authentication auth_token (Volto/REST API) ticket`: when selected the user will be allowed to act as a logged-in user in the Volto frontend.
-  - `Open ID scopes to request to the server`: information requested to the OIDC provider. Leave it as it is or modify it according to your provider's information.
-  - `Use PKCE`: when enabled uses [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) when requesting authentication from the provider.
+  * `Use Zope session data manager`: see the section below about the usage of session.
+  * `Create user / update user properties`: when selected the user data in Plone will be updated with the data coming from the OIDC provider.
+  * `Create authentication __ac ticket`: when selected the user will be allowed to act as a logged-in user in Plone.
+  * `Create authentication auth_token (Volto/REST API) ticket`: when selected the user will be allowed to act as a logged-in user in the Volto frontend.
+  * `Open ID scopes to request to the server`: information requested to the OIDC provider. Leave it as it is or modify it according to your provider's information.
+  * `Use PKCE`: when enabled uses [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) when requesting authentication from the provider.
 
 ### Login and Logout URLs
 
@@ -76,8 +78,8 @@ Pay attention to the customization of `User info property used as userid` field,
 
 When using this plugin with a [Volto frontend](https://6.docs.plone.org/volto/index.html), please install [@plone-collective/volto-authomatic](https://github.com/collective/volto-authomatic) add-on on your frontend project.
 
-- **Login URL**: `<Path to your Plone site>`/login
-- **Logout URL**: `<Path to your Plone site>`/logout
+* **Login URL**: `<Path to your Plone site>`/login
+* **Logout URL**: `<Path to your Plone site>`/logout
 
 Also, on the OpenID provider, configure the Redirect URL as **`<Path to your Plone site>`/login_oidc/oidc**.
 
@@ -88,14 +90,14 @@ will not trigger the usage of the plugin.
 
 To login into a site using the OIDC provider, you will need to change those login URLs to the following:
 
-- **Login URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/login
-- **Logout URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/logout
+* **Login URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/login
+* **Logout URL**: /`<Plone Site Id>`/acl_users/`<oidc pas plugin id>`/logout
 
-_Where:_
+*Where:*
 
-- `Plone Site Id`: is the id you gave to the Plone site when you created it. It is usually `Plone` but may vary. It is the last part of the URL when you browse Plone directly without using any proxy server, ex. `http://localhost:8080/Plone+` -> `Plone`.
+  * `Plone Site Id`: is the id you gave to the Plone site when you created it. It is usually `Plone` but may vary. It is the last part of the URL when you browse Plone directly without using any proxy server, ex. `http://localhost:8080/Plone+` -> `Plone`.
 
-- `oidc pas plugin id`: is the id you gave to the OIDC plugin when you created it inside the Plone PAS administration panel. If you just used the default configuration and installed this plugin using Plone's Add-on Control Panel, this id will be `oidc`.
+  * `oidc pas plugin id`: is the id you gave to the OIDC plugin when you created it inside the Plone PAS administration panel. If you just used the default configuration and installed this plugin using Plone's Add-on Control Panel, this id will be `oidc`.
 
 ### Example setup with Keycloak
 
@@ -196,9 +198,9 @@ See this screenshot:
 Go to the other browser, or logout as admin from [Keycloak Admin Console](http://localhost:8080/admin).
 Currently, the Plone login form is unchanged.
 
-Instead, for testing go to the login page of the plugin: http://localhost:8081/Plone/acl_users/oidc/login,
+Instead, for testing go to the login page of the plugin: http://localhost:8081/Plone/acl*users/oidc/login,
 this will take you to Keycloak to login, and then return. You should now be logged in to Plone, and see the
-_full name_ and _email_, if you have set this in Keycloak.
+\_full name* and _email_, if you have set this in Keycloak.
 
 #### Logout
 
@@ -220,7 +222,7 @@ Go to the Apple Developer Portal and create a new App ID in the [Certificates, I
 
 2. Create a Service ID
 
-In the same page, create a new Service ID. The identifier you will add here will be the client_id to be used when configuring the login process. Use the reverse-domain-name style notation to create this id, something like: com.yourcompany.yoursite. Tick the _Sign in with Apple_ option. Click on _Configure_ next to the option and set your application domain and the callback url. You must enter an _https_ URL.
+In the same page, create a new Service ID. The identifier you will add here will be the client*id to be used when configuring the login process. Use the reverse-domain-name style notation to create this id, something like: com.yourcompany.yoursite. Tick the \_Sign in with Apple* option. Click on _Configure_ next to the option and set your application domain and the callback url. You must enter an _https_ URL.
 
 3. Create a Private key
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "plone.api",
         "plone.restapi>=8.34.0",
         "oic",
-        "jwt",
+        "PyJWT",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "plone.api",
         "plone.restapi>=8.34.0",
         "oic",
-        "PyJWT",
+        "jwt",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "plone.api",
         "plone.restapi>=8.34.0",
         "oic",
+        "PyJWT",
     ],
     extras_require={
         "test": [

--- a/src/pas/plugins/oidc/__init__.py
+++ b/src/pas/plugins/oidc/__init__.py
@@ -1,4 +1,5 @@
 """Init and utils."""
+
 from AccessControl.Permissions import manage_users as ManageUsers
 from Products.PluggableAuthService import PluggableAuthService as PAS
 from zope.i18nmessageid import MessageFactory

--- a/src/pas/plugins/oidc/__init__.py
+++ b/src/pas/plugins/oidc/__init__.py
@@ -23,5 +23,6 @@ def initialize(context):  # pragma: no cover
     context.registerClass(
         plugins.OIDCPlugin,
         permission=ManageUsers,
-        constructors=(plugins.add_oidc_plugin,),
+        constructors=(plugins.manage_addOIDCPluginForm, plugins.addOIDCPlugin),
+        visibility=None,
     )

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -10,6 +10,9 @@ from Products.Five.browser import BrowserView
 from urllib.parse import quote
 from zExceptions import Unauthorized
 
+import json
+import urllib.parse
+
 
 class RequireLoginView(BrowserView):
     """Our version of the require-login view from Plone.
@@ -120,6 +123,10 @@ class CallbackView(BrowserView):
         session = utils.load_existing_session(self.context, self.request)
         client = self.context.get_oauth2_client()
         qs = self.request.environ["QUERY_STRING"]
+        if not qs:
+            # With Apple, the response comes as a POST, thus it does not
+            # com in the QUERY_STRING but in the request.form
+            qs = urllib.parse.urlencode(self.request.form)
         args, state = utils.parse_authorization_response(
             self.context, qs, client, session
         )
@@ -130,10 +137,35 @@ class CallbackView(BrowserView):
                     "phone_number_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
                 }
             )
-
         # The response you get back is an instance of an AccessTokenResponse
         # or again possibly an ErrorResponse instance.
+
+        if self.context.getProperty('apple_login_enabled'):
+            args.update(
+                {
+                    "client_id": self.context.getProperty("client_id"),
+                    "client_secret": self.context._build_apple_secret()
+                }
+            )
+
+        initial_user_info = {}
+        if self.context.getProperty('apple_login_enabled'):
+            # Let's check if this is this user's first login
+            # if so, their name and email could come in the first
+            # response from authorization response
+            # Weird Apple issues...
+            user = self.request.form.get('user', "")
+            if user:
+                user_decoded = json.loads(user)
+                first_name = user_decoded.get("name", {}).get("firstName", "")
+                last_name = user_decoded.get("name", {}).get("lastName", "")
+                email = user_decoded.get("email", "")
+                initial_user_info['given_name'] = first_name
+                initial_user_info['family_name'] = last_name
+                initial_user_info['email'] = email
+
         user_info = utils.get_user_info(client, state, args)
+        user_info.update(initial_user_info)
         if user_info:
             self.context.rememberIdentity(user_info)
             self.request.response.setHeader(

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -140,29 +140,29 @@ class CallbackView(BrowserView):
         # The response you get back is an instance of an AccessTokenResponse
         # or again possibly an ErrorResponse instance.
 
-        if self.context.getProperty('apple_login_enabled'):
+        if self.context.getProperty("apple_login_enabled"):
             args.update(
                 {
                     "client_id": self.context.getProperty("client_id"),
-                    "client_secret": self.context._build_apple_secret()
+                    "client_secret": self.context._build_apple_secret(),
                 }
             )
 
         initial_user_info = {}
-        if self.context.getProperty('apple_login_enabled'):
+        if self.context.getProperty("apple_login_enabled"):
             # Let's check if this is this user's first login
             # if so, their name and email could come in the first
             # response from authorization response
             # Weird Apple issues...
-            user = self.request.form.get('user', "")
+            user = self.request.form.get("user", "")
             if user:
                 user_decoded = json.loads(user)
                 first_name = user_decoded.get("name", {}).get("firstName", "")
                 last_name = user_decoded.get("name", {}).get("lastName", "")
                 email = user_decoded.get("email", "")
-                initial_user_info['given_name'] = first_name
-                initial_user_info['family_name'] = last_name
-                initial_user_info['email'] = email
+                initial_user_info["given_name"] = first_name
+                initial_user_info["family_name"] = last_name
+                initial_user_info["email"] = email
 
         user_info = utils.get_user_info(client, state, args)
         user_info.update(initial_user_info)

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -1,4 +1,5 @@
 """Module where all interfaces, events and exceptions live."""
+
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 

--- a/src/pas/plugins/oidc/locales/update.py
+++ b/src/pas/plugins/oidc/locales/update.py
@@ -1,4 +1,5 @@
 """Update locales."""
+
 from pathlib import Path
 
 import logging

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -6,6 +6,7 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from pas.plugins.oidc import logger
+from pas.plugins.oidc import PLUGIN_ID
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
@@ -24,7 +25,7 @@ import itertools
 import jwt
 import plone.api as api
 import string
-
+import time
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 
 
@@ -92,6 +93,9 @@ class OIDCPlugin(BasePlugin):
     use_deprecated_redirect_uri_for_logout = False
     use_modified_openid_schema = False
     user_property_as_userid = "sub"
+    apple_login_enabled = False
+    apple_consumer_team = ""
+    apple_consumer_id_key = ""
 
     _properties = (
         dict(id="issuer", type="string", mode="w", label="OIDC/Oauth2 Issuer"),
@@ -159,7 +163,29 @@ class OIDCPlugin(BasePlugin):
             mode="w",
             label="User info property used as userid, default 'sub'",
         ),
+        dict(
+            id="apple_login_enabled",
+            type="boolean",
+            mode="w",
+            label="Check if you want to login with Apple",
+        ),
+        dict(
+            id="apple_consumer_team",
+            type="string",
+            mode="w",
+            label="Apple consumer team as defined by Apple",
+        ),
+        dict(
+            id="apple_consumer_id_key",
+            type="string",
+            mode="w",
+            label="Apple consumer id key as defined by Apple",
+        ),
+
     )
+
+    APPLE_TOKEN_TTL_SEC = 6 * 30 * 24 * 60 * 60
+    APPLE_TOKEN_AUDIENCE = "https://appleid.apple.com"
 
     def __init__(self, id, title=None):
         self._setId(id)
@@ -323,6 +349,26 @@ class OIDCPlugin(BasePlugin):
             # TODO: take care of path, cookiename and domain options ?
             response.setCookie("auth_token", token, path="/")
 
+    def _build_apple_secret(self):
+        now = int(time.time())
+
+        client_id = self.getProperty("client_id")
+        team_id = self.getProperty('apple_consumer_team')
+        key_id = self.getProperty('apple_consumer_id_key')
+        private_key = self.getProperty('client_secret')
+
+        headers = {"kid": key_id}
+        payload = {
+            "iss": team_id,
+            "iat": now,
+            "exp": now + self.APPLE_TOKEN_TTL_SEC,
+            "aud": self.APPLE_TOKEN_AUDIENCE,
+            "sub": client_id,
+        }
+
+        private_key = f'-----BEGIN PRIVATE KEY-----\n{private_key}\n-----END PRIVATE KEY-----'
+        return jwt.encode(payload, key=private_key.encode(), algorithm="ES256", headers=headers)
+
     # TODO: memoize (?)
     def get_oauth2_client(self):
         try:
@@ -335,8 +381,16 @@ class OIDCPlugin(BasePlugin):
             provider_info = client.provider_config(self.getProperty("issuer"))  # noqa
             info = {
                 "client_id": self.getProperty("client_id"),
-                "client_secret": self.getProperty("client_secret"),
+                "token_endpoint_auth_method": provider_info.get(
+                    "token_endpoint_auth_methods_supported"
+                ),
             }
+
+            if self.getProperty('apple_login_enabled'):
+                info.update({"client_secret": self._build_apple_secret()})
+            else:
+                info.update({"client_secret": self.getProperty("client_secret")})
+
             client_reg = RegistrationResponse(**info)
             client.store_registration_info(client_reg)
             return client

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -6,7 +6,6 @@ from oic.oic.message import OpenIDSchema
 from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from pas.plugins.oidc import logger
-from pas.plugins.oidc import PLUGIN_ID
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -9,6 +9,7 @@ from pas.plugins.oidc import logger
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
 from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from Products.PluggableAuthService.interfaces.plugins import IUserAdderPlugin
@@ -25,7 +26,6 @@ import jwt
 import plone.api as api
 import string
 import time
-from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 
 
 manage_addOIDCPluginForm = PageTemplateFile(

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -21,8 +21,32 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 import itertools
+import jwt
 import plone.api as api
 import string
+
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+
+
+manage_addOIDCPluginForm = PageTemplateFile(
+    "www/oidcPluginForm", globals(), __name__="manage_addOIDCPluginForm"
+)
+
+
+def addOIDCPlugin(dispatcher, id, title=None, REQUEST=None):
+    """Add a HTTP Basic Auth Helper to a Pluggable Auth Service."""
+    plugin = OIDCPlugin(
+        id, title
+    )
+    dispatcher._setObject(plugin.getId(), plugin)
+
+
+    if REQUEST is not None:
+        REQUEST["RESPONSE"].redirect(
+            "%s/manage_workspace"
+            "?manage_tabs_message="
+            "OIDC+Plugin+added." % dispatcher.absolute_url()
+        )
 
 
 PWCHARS = string.ascii_letters + string.digits + string.punctuation
@@ -136,6 +160,10 @@ class OIDCPlugin(BasePlugin):
             label="User info property used as userid, default 'sub'",
         ),
     )
+
+    def __init__(self, id, title=None):
+        self._setId(id)
+        self.title = title
 
     def rememberIdentity(self, userinfo):
         if not isinstance(userinfo, (OpenIDSchema, dict)):
@@ -365,12 +393,6 @@ classImplements(
     # IPropertiesPlugin,
     # IRolesPlugin,
 )
-
-
-def add_oidc_plugin():
-    # Form for manually adding our plugin.
-    # But we do this in setuphandlers.py always.
-    pass
 
 
 # https://github.com/collective/Products.AutoUserMakerPASPlugin/blob/master/Products/AutoUserMakerPASPlugin/auth.py

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -180,6 +180,7 @@ class OIDCPlugin(BasePlugin):
     )
 
     APPLE_TOKEN_TTL_SEC = 6 * 30 * 24 * 60 * 60
+    # nosec bandit: disable hardcoded_password_string
     APPLE_TOKEN_AUDIENCE = "https://appleid.apple.com"
 
     def __init__(self, id, title=None):

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -180,8 +180,9 @@ class OIDCPlugin(BasePlugin):
     )
 
     APPLE_TOKEN_TTL_SEC = 6 * 30 * 24 * 60 * 60
-    # nosec bandit: disable hardcoded_password_string
-    APPLE_TOKEN_AUDIENCE = "https://appleid.apple.com"
+    APPLE_TOKEN_AUDIENCE = (
+        "https://appleid.apple.com"  # nosec bandit: disable hardcoded_password_string
+    )
 
     def __init__(self, id, title=None):
         self._setId(id)

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -35,11 +35,8 @@ manage_addOIDCPluginForm = PageTemplateFile(
 
 def addOIDCPlugin(dispatcher, id, title=None, REQUEST=None):
     """Add a HTTP Basic Auth Helper to a Pluggable Auth Service."""
-    plugin = OIDCPlugin(
-        id, title
-    )
+    plugin = OIDCPlugin(id, title)
     dispatcher._setObject(plugin.getId(), plugin)
-
 
     if REQUEST is not None:
         REQUEST["RESPONSE"].redirect(
@@ -180,7 +177,6 @@ class OIDCPlugin(BasePlugin):
             mode="w",
             label="Apple consumer id key as defined by Apple",
         ),
-
     )
 
     APPLE_TOKEN_TTL_SEC = 6 * 30 * 24 * 60 * 60
@@ -352,9 +348,9 @@ class OIDCPlugin(BasePlugin):
         now = int(time.time())
 
         client_id = self.getProperty("client_id")
-        team_id = self.getProperty('apple_consumer_team')
-        key_id = self.getProperty('apple_consumer_id_key')
-        private_key = self.getProperty('client_secret')
+        team_id = self.getProperty("apple_consumer_team")
+        key_id = self.getProperty("apple_consumer_id_key")
+        private_key = self.getProperty("client_secret")
 
         headers = {"kid": key_id}
         payload = {
@@ -365,8 +361,12 @@ class OIDCPlugin(BasePlugin):
             "sub": client_id,
         }
 
-        private_key = f'-----BEGIN PRIVATE KEY-----\n{private_key}\n-----END PRIVATE KEY-----'
-        return jwt.encode(payload, key=private_key.encode(), algorithm="ES256", headers=headers)
+        private_key = (
+            f"-----BEGIN PRIVATE KEY-----\n{private_key}\n-----END PRIVATE KEY-----"
+        )
+        return jwt.encode(
+            payload, key=private_key.encode(), algorithm="ES256", headers=headers
+        )
 
     # TODO: memoize (?)
     def get_oauth2_client(self):
@@ -385,7 +385,7 @@ class OIDCPlugin(BasePlugin):
                 ),
             }
 
-            if self.getProperty('apple_login_enabled'):
+            if self.getProperty("apple_login_enabled"):
                 info.update({"client_secret": self._build_apple_secret()})
             else:
                 info.update({"client_secret": self.getProperty("client_secret")})

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -384,7 +384,7 @@ class OIDCPlugin(BasePlugin):
                 "client_id": self.getProperty("client_id"),
                 "token_endpoint_auth_method": provider_info.get(
                     "token_endpoint_auth_methods_supported"
-                ),
+                )[0],
             }
 
             if self.getProperty("apple_login_enabled"):

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -42,7 +42,9 @@ class LoginOIDC(Service):
     def plugin(self) -> OIDCPlugin:
         if not self._plugin:
             try:
-                self._plugin = utils.get_plugin()
+                for plugin in utils.get_plugins():
+                    if plugin.getId() == self.provider_id:
+                        self._plugin = plugin
             except AttributeError:
                 # Plugin not installed yet
                 self._plugin = None
@@ -77,7 +79,8 @@ class Get(LoginOIDC):
         """
         provider = self.provider_id
         plugin = self.plugin
-        if not (plugin and provider == "oidc"):
+
+        if not plugin:
             return self._provider_not_found(provider)
 
         session = utils.initialize_session(plugin, self.request)

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -70,7 +70,9 @@ def activate_plugin(context, interface_name, move_to_top=False):
             iface = plugins._getInterfaceFromName(interface_name)
             if plugin.getId() not in plugins.listPluginIds(iface):
                 plugins.activatePlugin(iface, plugin.getId())
-                logger.info(f"Activated interface {interface_name} for plugin {plugin.getId()}")
+                logger.info(
+                    f"Activated interface {interface_name} for plugin {plugin.getId()}"
+                )
 
             if move_to_top:
                 # Order some plugins to make sure our plugin is at the top.
@@ -81,6 +83,7 @@ def activate_plugin(context, interface_name, move_to_top=False):
 
 def activate_challenge_plugin(context):
     activate_plugin(context, "IChallengePlugin", move_to_top=True)
+
 
 def uninstall(context):
     """Uninstall script"""

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -23,6 +23,7 @@ def post_install(context):
     # Create plugin if it does not exist.
     if PLUGIN_ID not in pas.objectIds():
         plugin = OIDCPlugin(
+            id=PLUGIN_ID,
             title="OpenID Connect",
         )
         plugin.id = PLUGIN_ID

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -63,7 +63,6 @@ def activate_plugin(context, interface_name, move_to_top=False):
     pas = api.portal.get_tool("acl_users")
     for plugin in pas.objectValues():
         if isinstance(plugin, OIDCPlugin):
-
             # This would activate one interface and deactivate all others:
             # plugin.manage_activateInterfaces([interface_name])
             # So only take over the necessary code from manage_activateInterfaces.

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -128,8 +128,8 @@ def authorization_flow_args(plugin: plugins.OIDCPlugin, session: Session) -> dic
         args["code_challenge"] = pkce_code_verifier_challenge(session.get("verifier"))
         args["code_challenge_method"] = "S256"
 
-    if plugin.getProperty('apple_login_enabled'):
-        args['response_mode'] = 'form_post'
+    if plugin.getProperty("apple_login_enabled"):
+        args["response_mode"] = "form_post"
 
     return args
 
@@ -172,7 +172,9 @@ def get_user_info(client, state, args) -> Union[message.OpenIDSchema, dict]:
     resp = client.do_access_token_request(
         state=state,
         request_args=args,
-        authn_method=client.registration_response.get('token_endpoint_auth_method', 'client_secret_basic'),
+        authn_method=client.registration_response.get(
+            "token_endpoint_auth_method", "client_secret_basic"
+        ),
     )
     user_info = {}
     if isinstance(resp, message.AccessTokenResponse):

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -170,7 +170,9 @@ def parse_authorization_response(
 
 def get_user_info(client, state, args) -> Union[message.OpenIDSchema, dict]:
     # Decide which authentication method to use
-    allowed_authn_methods = client.registration_response.get("token_endpoint_auth_method")
+    allowed_authn_methods = client.registration_response.get(
+        "token_endpoint_auth_method"
+    )
     if allowed_authn_methods and isinstance(allowed_authn_methods, list):
         # arbitrary decision: take the first one
         allowed_authn_method = allowed_authn_methods[0]
@@ -181,9 +183,7 @@ def get_user_info(client, state, args) -> Union[message.OpenIDSchema, dict]:
         allowed_authn_method = "client_secret_basic"
 
     resp = client.do_access_token_request(
-        state=state,
-        request_args=args,
-        authn_method=allowed_authn_method
+        state=state, request_args=args, authn_method=allowed_authn_method
     )
     user_info = {}
     if isinstance(resp, message.AccessTokenResponse):

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -5,6 +5,7 @@ from oic.oic import message
 from pas.plugins.oidc import logger
 from pas.plugins.oidc import PLUGIN_ID
 from pas.plugins.oidc import plugins
+from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session
 from plone import api
 from typing import Union
@@ -77,10 +78,15 @@ def url_cleanup(url: str) -> str:
     return url
 
 
-def get_plugin() -> plugins.OIDCPlugin:
-    """Return the OIDC plugin for the current portal."""
+def get_plugins() -> list:
+    """ Return all OIDC plugins for the current portal."""
     pas = api.portal.get_tool("acl_users")
-    return getattr(pas, PLUGIN_ID)
+    plugins_to_return = []
+    for plugin in pas.objectValues():
+        if isinstance(plugin, OIDCPlugin):
+            plugins_to_return.append(plugin)
+
+    return plugins_to_return
 
 
 # Flow: Start

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -169,12 +169,21 @@ def parse_authorization_response(
 
 
 def get_user_info(client, state, args) -> Union[message.OpenIDSchema, dict]:
+    # Decide which authentication method to use
+    allowed_authn_methods = client.registration_response.get("token_endpoint_auth_method")
+    if allowed_authn_methods and isinstance(allowed_authn_methods, list):
+        # arbitrary decision: take the first one
+        allowed_authn_method = allowed_authn_methods[0]
+    elif allowed_authn_methods and isinstance(allowed_authn_methods, str):
+        allowed_authn_method = allowed_authn_methods
+    else:
+        # If nothing is returned, try with the most basic one
+        allowed_authn_method = "client_secret_basic"
+
     resp = client.do_access_token_request(
         state=state,
         request_args=args,
-        authn_method=client.registration_response.get(
-            "token_endpoint_auth_method", "client_secret_basic"
-        ),
+        authn_method=allowed_authn_method
     )
     user_info = {}
     if isinstance(resp, message.AccessTokenResponse):

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,0 +1,37 @@
+<h1 tal:replace="structure here/manage_page_header">Header</h1>
+
+<main class="container-fluid">
+
+  <h2 tal:define="form_title string:Add OIDC Plugin"
+      tal:replace="structure here/manage_form_title">Form Title</h2>
+
+  <p class="form-help">
+    OIDC Plugin manage the details of the OpenID Connect Authentication plugin
+    Pluggable Auth Service functionality.
+  </p>
+
+  <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
+
+    <div class="form-group row">
+      <label for="id" class="form-label col-sm-3 col-md-2">Id</label>
+      <div class="col-sm-9 col-md-10">
+        <input id="id" name="id" class="form-control" type="text" />
+      </div>
+    </div>
+
+    <div class="form-group row form-optional">
+      <label for="title" class="form-label col-sm-3 col-md-2">Title</label>
+      <div class="col-sm-9 col-md-10">
+        <input id="title" name="title" class="form-control" type="text" />
+      </div>
+    </div>
+
+    <div class="zmi-controls">
+      <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+    </div>
+
+  </form>
+
+</main>
+
+<h1 tal:replace="structure here/manage_page_footer">Footer</h1>

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,11 +1,11 @@
 <h1 tal:replace="structure here/manage_page_header">Header</h1>
 
-<main class="container-fluid">
+<main class="container-fluid" i18n:domain="pas.plugins.oidc">
 
   <h2 tal:define="form_title string:Add OIDC Plugin"
       tal:replace="structure here/manage_form_title">Form Title</h2>
 
-  <p class="form-help">
+  <p class="form-help" i18n:translate="">
     OIDC Plugin manage the details of the OpenID Connect Authentication plugin
     Pluggable Auth Service functionality.
   </p>
@@ -13,21 +13,21 @@
   <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
 
     <div class="form-group row">
-      <label for="id" class="form-label col-sm-3 col-md-2">Id</label>
+      <label for="id" class="form-label col-sm-3 col-md-2" i18n:translate="">Id</label>
       <div class="col-sm-9 col-md-10">
         <input id="id" name="id" class="form-control" type="text" />
       </div>
     </div>
 
     <div class="form-group row form-optional">
-      <label for="title" class="form-label col-sm-3 col-md-2">Title</label>
+      <label for="title" class="form-label col-sm-3 col-md-2" i18n:translate="">Title</label>
       <div class="col-sm-9 col-md-10">
         <input id="title" name="title" class="form-control" type="text" />
       </div>
     </div>
 
     <div class="zmi-controls">
-      <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+      <input class="btn btn-primary" type="submit" name="submit" value="Add" i18n:attributes="value"/>
     </div>
 
   </form>

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,33 +1,62 @@
 <h1 tal:replace="structure here/manage_page_header">Header</h1>
 
-<main class="container-fluid" i18n:domain="pas.plugins.oidc">
+<main class="container-fluid"
+      i18n:domain="pas.plugins.oidc"
+>
 
-  <h2 tal:define="form_title string:Add OIDC Plugin"
-      tal:replace="structure here/manage_form_title">Form Title</h2>
+  <h2 tal:define="
+        form_title string:Add OIDC Plugin;
+      "
+      tal:replace="structure here/manage_form_title"
+  >Form Title</h2>
 
-  <p class="form-help" i18n:translate="">
+  <p class="form-help"
+     i18n:translate=""
+  >
     OIDC Plugin manage the details of the OpenID Connect Authentication plugin
     Pluggable Auth Service functionality.
   </p>
 
-  <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
+  <form action="addOIDCPlugin"
+        enctype="multipart/form-data"
+        method="post"
+  >
 
     <div class="form-group row">
-      <label for="id" class="form-label col-sm-3 col-md-2" i18n:translate="">Id</label>
+      <label class="form-label col-sm-3 col-md-2"
+             for="id"
+             i18n:translate=""
+      >Id</label>
       <div class="col-sm-9 col-md-10">
-        <input id="id" name="id" class="form-control" type="text" />
+        <input class="form-control"
+               id="id"
+               name="id"
+               type="text"
+        />
       </div>
     </div>
 
     <div class="form-group row form-optional">
-      <label for="title" class="form-label col-sm-3 col-md-2" i18n:translate="">Title</label>
+      <label class="form-label col-sm-3 col-md-2"
+             for="title"
+             i18n:translate=""
+      >Title</label>
       <div class="col-sm-9 col-md-10">
-        <input id="title" name="title" class="form-control" type="text" />
+        <input class="form-control"
+               id="title"
+               name="title"
+               type="text"
+        />
       </div>
     </div>
 
     <div class="zmi-controls">
-      <input class="btn btn-primary" type="submit" name="submit" value="Add" i18n:attributes="value"/>
+      <input class="btn btn-primary"
+             name="submit"
+             type="submit"
+             value="Add"
+             i18n:attributes="value"
+      />
     </div>
 
   </form>


### PR DESCRIPTION
[Sign in with Apple](https://developer.apple.com/documentation/sign_in_with_apple/implementing_user_authentication_with_sign_in_with_apple) is an OpenID Connect*ish* interface to allow users sign in using their Apple credentials.

It has some peculiarities like:

- It uses the `client_secret_post` authentication method when requesting the access token
- It needs to create a specific secret based on the private key instead of a fixed `client_secret`, which in itself is a JWT token **but** it doesn't use the `private_key_jwt` authentication mechanism that OIDC provides :disappointed_relieved: 
- It returns user's name **only** after first login and as a response to the access token request and not in the user info phase :see_no_evil: 

Together with these changes I have added the support for adding extra OIDC plugins (in case you need to have more than one OIDC providers in your site).

