### PR TITLE
Allow adding multiple oidc plugins to your site

### DIFF
--- a/news/48.feature
+++ b/news/48.feature
@@ -1,0 +1,1 @@
+Allow multiple instances of OIDC plugin in a given Plone site @erral

--- a/src/pas/plugins/oidc/__init__.py
+++ b/src/pas/plugins/oidc/__init__.py
@@ -1,4 +1,5 @@
 """Init and utils."""
+
 from AccessControl.Permissions import manage_users as ManageUsers
 from Products.PluggableAuthService import PluggableAuthService as PAS
 from zope.i18nmessageid import MessageFactory

--- a/src/pas/plugins/oidc/__init__.py
+++ b/src/pas/plugins/oidc/__init__.py
@@ -23,5 +23,6 @@ def initialize(context):  # pragma: no cover
     context.registerClass(
         plugins.OIDCPlugin,
         permission=ManageUsers,
-        constructors=(plugins.add_oidc_plugin,),
+        constructors=(plugins.manage_addOIDCPluginForm, plugins.addOIDCPlugin),
+        visibility=None,
     )

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -1,4 +1,5 @@
 """Module where all interfaces, events and exceptions live."""
+
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 

--- a/src/pas/plugins/oidc/locales/update.py
+++ b/src/pas/plugins/oidc/locales/update.py
@@ -1,4 +1,5 @@
 """Update locales."""
+
 from pathlib import Path
 
 import logging

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -77,6 +77,7 @@ class OIDCPlugin(BasePlugin):
     meta_type = "OIDC Plugin"
     security = ClassSecurityInfo()
 
+    title = "OIDC Plugin"
     issuer = ""
     client_id = ""
     client_secret = ""  # nosec B105
@@ -94,6 +95,7 @@ class OIDCPlugin(BasePlugin):
     user_property_as_userid = "sub"
 
     _properties = (
+        dict(id="title", type="string", mode="w", label="Title"),
         dict(id="issuer", type="string", mode="w", label="OIDC/Oauth2 Issuer"),
         dict(id="client_id", type="string", mode="w", label="Client ID"),
         dict(id="client_secret", type="string", mode="w", label="Client secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -21,8 +21,32 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 import itertools
+import jwt
 import plone.api as api
 import string
+
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+
+
+manage_addOIDCPluginForm = PageTemplateFile(
+    "www/oidcPluginForm", globals(), __name__="manage_addOIDCPluginForm"
+)
+
+
+def addOIDCPlugin(dispatcher, id, title=None, REQUEST=None):
+    """Add a HTTP Basic Auth Helper to a Pluggable Auth Service."""
+    plugin = OIDCPlugin(
+        id, title
+    )
+    dispatcher._setObject(plugin.getId(), plugin)
+
+
+    if REQUEST is not None:
+        REQUEST["RESPONSE"].redirect(
+            "%s/manage_workspace"
+            "?manage_tabs_message="
+            "OIDC+Plugin+added." % dispatcher.absolute_url()
+        )
 
 
 PWCHARS = string.ascii_letters + string.digits + string.punctuation
@@ -136,6 +160,10 @@ class OIDCPlugin(BasePlugin):
             label="User info property used as userid, default 'sub'",
         ),
     )
+
+    def __init__(self, id, title=None):
+        self._setId(id)
+        self.title = title
 
     def rememberIdentity(self, userinfo):
         if not isinstance(userinfo, (OpenIDSchema, dict)):
@@ -365,12 +393,6 @@ classImplements(
     # IPropertiesPlugin,
     # IRolesPlugin,
 )
-
-
-def add_oidc_plugin():
-    # Form for manually adding our plugin.
-    # But we do this in setuphandlers.py always.
-    pass
 
 
 # https://github.com/collective/Products.AutoUserMakerPASPlugin/blob/master/Products/AutoUserMakerPASPlugin/auth.py

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -1,32 +1,26 @@
+import itertools
+import string
+from contextlib import contextmanager
+from secrets import choice
+from typing import List
+
+import plone.api as api
 from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
-from contextlib import contextmanager
 from oic.oic import Client
-from oic.oic.message import OpenIDSchema
-from oic.oic.message import RegistrationResponse
+from oic.oic.message import OpenIDSchema, RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from pas.plugins.oidc import logger
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
-from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
-from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
-from Products.PluggableAuthService.interfaces.plugins import IUserAdderPlugin
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+from Products.PluggableAuthService.interfaces.plugins import (
+    IAuthenticationPlugin, IChallengePlugin, IUserAdderPlugin)
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
-from secrets import choice
-from typing import List
 from ZODB.POSException import ConflictError
-from zope.interface import implementer
-from zope.interface import Interface
-
-import itertools
-import jwt
-import plone.api as api
-import string
-
-from Products.PageTemplates.PageTemplateFile import PageTemplateFile
-
+from zope.interface import Interface, implementer
 
 manage_addOIDCPluginForm = PageTemplateFile(
     "www/oidcPluginForm", globals(), __name__="manage_addOIDCPluginForm"

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -35,11 +35,8 @@ manage_addOIDCPluginForm = PageTemplateFile(
 
 def addOIDCPlugin(dispatcher, id, title=None, REQUEST=None):
     """Add a HTTP Basic Auth Helper to a Pluggable Auth Service."""
-    plugin = OIDCPlugin(
-        id, title
-    )
+    plugin = OIDCPlugin(id, title)
     dispatcher._setObject(plugin.getId(), plugin)
-
 
     if REQUEST is not None:
         REQUEST["RESPONSE"].redirect(

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -1,26 +1,30 @@
-import itertools
-import string
-from contextlib import contextmanager
-from secrets import choice
-from typing import List
-
-import plone.api as api
 from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
+from contextlib import contextmanager
 from oic.oic import Client
-from oic.oic.message import OpenIDSchema, RegistrationResponse
+from oic.oic.message import OpenIDSchema
+from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from pas.plugins.oidc import logger
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
 from Products.CMFCore.utils import getToolByName
 from Products.PageTemplates.PageTemplateFile import PageTemplateFile
-from Products.PluggableAuthService.interfaces.plugins import (
-    IAuthenticationPlugin, IChallengePlugin, IUserAdderPlugin)
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
+from Products.PluggableAuthService.interfaces.plugins import IUserAdderPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
+from secrets import choice
+from typing import List
 from ZODB.POSException import ConflictError
-from zope.interface import Interface, implementer
+from zope.interface import implementer
+from zope.interface import Interface
+
+import itertools
+import plone.api as api
+import string
+
 
 manage_addOIDCPluginForm = PageTemplateFile(
     "www/oidcPluginForm", globals(), __name__="manage_addOIDCPluginForm"

--- a/src/pas/plugins/oidc/services/login/get.py
+++ b/src/pas/plugins/oidc/services/login/get.py
@@ -1,7 +1,8 @@
+from typing import Dict, List
+
+from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from plone.restapi.services import Service
-from typing import Dict
-from typing import List
 
 
 class Get(Service):
@@ -18,14 +19,18 @@ class Get(Service):
         :returns: List of login options.
         """
         portal_url = api.portal.get().absolute_url()
-        plugins = [
-            {
-                "id": "oidc",
-                "plugin": "oidc",
-                "url": f"{portal_url}/@login-oidc/oidc",
-                "title": "OIDC Authentication",
-            }
-        ]
+        acl_users = api.portal.get_tool("acl_users")
+        plugins = []
+        for plugin in acl_users.objectValues():
+            if isinstance(plugin, OIDCPlugin):
+                plugins.append(
+                    {
+                        "id": plugin.getId(),
+                        "plugin": "oidc",
+                        "url": f"{portal_url}/@login-oidc/{plugin.getId()}",
+                        "title": plugin.title,
+                    }
+                )
         return plugins
 
     def reply(self) -> Dict[str, List[Dict]]:

--- a/src/pas/plugins/oidc/services/login/get.py
+++ b/src/pas/plugins/oidc/services/login/get.py
@@ -1,9 +1,9 @@
-from typing import Dict, List
-
 from pas.plugins.oidc import utils
 from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from plone.restapi.services import Service
+from typing import Dict
+from typing import List
 
 
 class Get(Service):

--- a/src/pas/plugins/oidc/services/login/get.py
+++ b/src/pas/plugins/oidc/services/login/get.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 
+from pas.plugins.oidc import utils
 from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from plone.restapi.services import Service
@@ -19,9 +20,8 @@ class Get(Service):
         :returns: List of login options.
         """
         portal_url = api.portal.get().absolute_url()
-        acl_users = api.portal.get_tool("acl_users")
         plugins = []
-        for plugin in acl_users.objectValues():
+        for plugin in utils.get_plugins():
             if isinstance(plugin, OIDCPlugin):
                 plugins.append(
                     {

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -1,21 +1,15 @@
-from oic.oic.message import EndSessionRequest
-from oic.oic.message import IdToken
-from pas.plugins.oidc import _
-from pas.plugins.oidc import logger
-from pas.plugins.oidc import utils
-from pas.plugins.oidc.plugins import OAuth2ConnectionException
-from pas.plugins.oidc.plugins import OIDCPlugin
+import transaction
+from oic.oic.message import EndSessionRequest, IdToken
+from pas.plugins.oidc import _, logger, utils
+from pas.plugins.oidc.plugins import OAuth2ConnectionException, OIDCPlugin
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from Products.PlonePAS.tools.memberdata import MemberData
 from transaction.interfaces import NoTransaction
-from zope.interface import alsoProvides
-from zope.interface import implementer
+from zope.interface import alsoProvides, implementer
 from zope.publisher.interfaces import IPublishTraverse
-
-import transaction
 
 
 @implementer(IPublishTraverse)

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -42,7 +42,9 @@ class LoginOIDC(Service):
     def plugin(self) -> OIDCPlugin:
         if not self._plugin:
             try:
-                self._plugin = utils.get_plugin()
+                for plugin in utils.get_plugins():
+                    if plugin.getId() == self.provider_id:
+                        self._plugin = plugin
             except AttributeError:
                 # Plugin not installed yet
                 self._plugin = None
@@ -77,7 +79,8 @@ class Get(LoginOIDC):
         """
         provider = self.provider_id
         plugin = self.plugin
-        if not (plugin and provider == "oidc"):
+
+        if not plugin:
             return self._provider_not_found(provider)
 
         session = utils.initialize_session(plugin, self.request)

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -1,15 +1,21 @@
-import transaction
-from oic.oic.message import EndSessionRequest, IdToken
-from pas.plugins.oidc import _, logger, utils
-from pas.plugins.oidc.plugins import OAuth2ConnectionException, OIDCPlugin
+from oic.oic.message import EndSessionRequest
+from oic.oic.message import IdToken
+from pas.plugins.oidc import _
+from pas.plugins.oidc import logger
+from pas.plugins.oidc import utils
+from pas.plugins.oidc.plugins import OAuth2ConnectionException
+from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from Products.PlonePAS.tools.memberdata import MemberData
 from transaction.interfaces import NoTransaction
-from zope.interface import alsoProvides, implementer
+from zope.interface import alsoProvides
+from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
+
+import transaction
 
 
 @implementer(IPublishTraverse)

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -124,10 +124,9 @@ class LogoutGet(LoginOIDC):
 
         :returns: URL and session information.
         """
-        provider = "oidc"
         plugin = self.plugin
-        if not (plugin and provider == "oidc"):
-            return self._provider_not_found(provider)
+        if not plugin:
+            return self._provider_not_found(self.provider_id)
 
         try:
             client = plugin.get_oauth2_client()
@@ -195,7 +194,7 @@ class Post(LoginOIDC):
         """
         provider = self.provider_id
         plugin = self.plugin
-        if not (plugin and provider == "oidc"):
+        if not plugin:
             return self._provider_not_found(provider)
 
         session = utils.load_existing_session(plugin, self.request)

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -23,6 +23,7 @@ def post_install(context):
     # Create plugin if it does not exist.
     if PLUGIN_ID not in pas.objectIds():
         plugin = OIDCPlugin(
+            id=PLUGIN_ID,
             title="OpenID Connect",
         )
         plugin.id = PLUGIN_ID

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -1,9 +1,10 @@
 from pas.plugins.oidc import logger
+from pas.plugins.oidc import PLUGIN_ID
+from pas.plugins.oidc import utils
 from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
-from pas.plugins.oidc import utils
 
 
 @implementer(INonInstallable)
@@ -95,4 +96,3 @@ def uninstall(context):
     for plugin in utils.get_plugins():
         pas._delObject(plugin.getId())
         logger.info(f"Removed OIDCPlugin {plugin.getId()} from acl_users.")
-

--- a/src/pas/plugins/oidc/setuphandlers.py
+++ b/src/pas/plugins/oidc/setuphandlers.py
@@ -1,9 +1,9 @@
 from pas.plugins.oidc import logger
-from pas.plugins.oidc import PLUGIN_ID
 from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from Products.CMFPlone.interfaces import INonInstallable
 from zope.interface import implementer
+from pas.plugins.oidc import utils
 
 
 @implementer(INonInstallable)
@@ -90,18 +90,9 @@ def activate_challenge_plugin(context):
 
 def uninstall(context):
     """Uninstall script"""
-    from pas.plugins.oidc.utils import PLUGIN_ID
-
     pas = api.portal.get_tool("acl_users")
 
-    # Remove plugin if it exists.
-    if PLUGIN_ID not in pas.objectIds():
-        return
-    from pas.plugins.oidc.plugins import OIDCPlugin
+    for plugin in utils.get_plugins():
+        pas._delObject(plugin.getId())
+        logger.info(f"Removed OIDCPlugin {plugin.getId()} from acl_users.")
 
-    plugin = getattr(pas, PLUGIN_ID)
-    if not isinstance(plugin, OIDCPlugin):
-        logger.warning(f"PAS plugin {PLUGIN_ID} not removed: it is not a OIDCPlugin.")
-        return
-    pas._delObject(PLUGIN_ID)
-    logger.info(f"Removed OIDCPlugin {PLUGIN_ID} from acl_users.")

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -1,15 +1,17 @@
-import base64
-import re
 from hashlib import sha256
-from typing import Union
-
 from oic import rndstr
 from oic.exception import RequestError
 from oic.oic import message
-from pas.plugins.oidc import PLUGIN_ID, logger, plugins
+from pas.plugins.oidc import logger
+from pas.plugins.oidc import PLUGIN_ID
+from pas.plugins.oidc import plugins
 from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session
 from plone import api
+from typing import Union
+
+import base64
+import re
 
 
 def boolean_string_ser(val, sformat=None, lev=0):

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -3,7 +3,6 @@ from oic import rndstr
 from oic.exception import RequestError
 from oic.oic import message
 from pas.plugins.oidc import logger
-from pas.plugins.oidc import PLUGIN_ID
 from pas.plugins.oidc import plugins
 from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -5,6 +5,7 @@ from oic.oic import message
 from pas.plugins.oidc import logger
 from pas.plugins.oidc import PLUGIN_ID
 from pas.plugins.oidc import plugins
+from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session
 from plone import api
 from typing import Union
@@ -77,10 +78,15 @@ def url_cleanup(url: str) -> str:
     return url
 
 
-def get_plugin() -> plugins.OIDCPlugin:
-    """Return the OIDC plugin for the current portal."""
+def get_plugins() -> list:
+    """ Return all OIDC plugins for the current portal."""
     pas = api.portal.get_tool("acl_users")
-    return getattr(pas, PLUGIN_ID)
+    plugins_to_return = []
+    for plugin in pas.objectValues():
+        if isinstance(plugin, OIDCPlugin):
+            plugins_to_return.append(plugin)
+
+    return plugins_to_return
 
 
 # Flow: Start

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -1,17 +1,15 @@
+import base64
+import re
 from hashlib import sha256
+from typing import Union
+
 from oic import rndstr
 from oic.exception import RequestError
 from oic.oic import message
-from pas.plugins.oidc import logger
-from pas.plugins.oidc import PLUGIN_ID
-from pas.plugins.oidc import plugins
+from pas.plugins.oidc import PLUGIN_ID, logger, plugins
 from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session
 from plone import api
-from typing import Union
-
-import base64
-import re
 
 
 def boolean_string_ser(val, sformat=None, lev=0):

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -79,7 +79,7 @@ def url_cleanup(url: str) -> str:
 
 
 def get_plugins() -> list:
-    """ Return all OIDC plugins for the current portal."""
+    """Return all OIDC plugins for the current portal."""
     pas = api.portal.get_tool("acl_users")
     plugins_to_return = []
     for plugin in pas.objectValues():

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,0 +1,37 @@
+<h1 tal:replace="structure here/manage_page_header">Header</h1>
+
+<main class="container-fluid">
+
+  <h2 tal:define="form_title string:Add OIDC Plugin"
+      tal:replace="structure here/manage_form_title">Form Title</h2>
+
+  <p class="form-help">
+    OIDC Plugin manage the details of the OpenID Connect Authentication plugin
+    Pluggable Auth Service functionality.
+  </p>
+
+  <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
+
+    <div class="form-group row">
+      <label for="id" class="form-label col-sm-3 col-md-2">Id</label>
+      <div class="col-sm-9 col-md-10">
+        <input id="id" name="id" class="form-control" type="text" />
+      </div>
+    </div>
+
+    <div class="form-group row form-optional">
+      <label for="title" class="form-label col-sm-3 col-md-2">Title</label>
+      <div class="col-sm-9 col-md-10">
+        <input id="title" name="title" class="form-control" type="text" />
+      </div>
+    </div>
+
+    <div class="zmi-controls">
+      <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+    </div>
+
+  </form>
+
+</main>
+
+<h1 tal:replace="structure here/manage_page_footer">Footer</h1>

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,11 +1,11 @@
 <h1 tal:replace="structure here/manage_page_header">Header</h1>
 
-<main class="container-fluid">
+<main class="container-fluid" i18n:domain="pas.plugins.oidc">
 
   <h2 tal:define="form_title string:Add OIDC Plugin"
       tal:replace="structure here/manage_form_title">Form Title</h2>
 
-  <p class="form-help">
+  <p class="form-help" i18n:translate="">
     OIDC Plugin manage the details of the OpenID Connect Authentication plugin
     Pluggable Auth Service functionality.
   </p>
@@ -13,21 +13,21 @@
   <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
 
     <div class="form-group row">
-      <label for="id" class="form-label col-sm-3 col-md-2">Id</label>
+      <label for="id" class="form-label col-sm-3 col-md-2" i18n:translate="">Id</label>
       <div class="col-sm-9 col-md-10">
         <input id="id" name="id" class="form-control" type="text" />
       </div>
     </div>
 
     <div class="form-group row form-optional">
-      <label for="title" class="form-label col-sm-3 col-md-2">Title</label>
+      <label for="title" class="form-label col-sm-3 col-md-2" i18n:translate="">Title</label>
       <div class="col-sm-9 col-md-10">
         <input id="title" name="title" class="form-control" type="text" />
       </div>
     </div>
 
     <div class="zmi-controls">
-      <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+      <input class="btn btn-primary" type="submit" name="submit" value="Add" i18n:attributes="value"/>
     </div>
 
   </form>

--- a/src/pas/plugins/oidc/www/oidcPluginForm.zpt
+++ b/src/pas/plugins/oidc/www/oidcPluginForm.zpt
@@ -1,33 +1,62 @@
 <h1 tal:replace="structure here/manage_page_header">Header</h1>
 
-<main class="container-fluid" i18n:domain="pas.plugins.oidc">
+<main class="container-fluid"
+      i18n:domain="pas.plugins.oidc"
+>
 
-  <h2 tal:define="form_title string:Add OIDC Plugin"
-      tal:replace="structure here/manage_form_title">Form Title</h2>
+  <h2 tal:define="
+        form_title string:Add OIDC Plugin;
+      "
+      tal:replace="structure here/manage_form_title"
+  >Form Title</h2>
 
-  <p class="form-help" i18n:translate="">
+  <p class="form-help"
+     i18n:translate=""
+  >
     OIDC Plugin manage the details of the OpenID Connect Authentication plugin
     Pluggable Auth Service functionality.
   </p>
 
-  <form action="addOIDCPlugin" method="post" enctype="multipart/form-data">
+  <form action="addOIDCPlugin"
+        enctype="multipart/form-data"
+        method="post"
+  >
 
     <div class="form-group row">
-      <label for="id" class="form-label col-sm-3 col-md-2" i18n:translate="">Id</label>
+      <label class="form-label col-sm-3 col-md-2"
+             for="id"
+             i18n:translate=""
+      >Id</label>
       <div class="col-sm-9 col-md-10">
-        <input id="id" name="id" class="form-control" type="text" />
+        <input class="form-control"
+               id="id"
+               name="id"
+               type="text"
+        />
       </div>
     </div>
 
     <div class="form-group row form-optional">
-      <label for="title" class="form-label col-sm-3 col-md-2" i18n:translate="">Title</label>
+      <label class="form-label col-sm-3 col-md-2"
+             for="title"
+             i18n:translate=""
+      >Title</label>
       <div class="col-sm-9 col-md-10">
-        <input id="title" name="title" class="form-control" type="text" />
+        <input class="form-control"
+               id="title"
+               name="title"
+               type="text"
+        />
       </div>
     </div>
 
     <div class="zmi-controls">
-      <input class="btn btn-primary" type="submit" name="submit" value="Add" i18n:attributes="value"/>
+      <input class="btn btn-primary"
+             name="submit"
+             type="submit"
+             value="Add"
+             i18n:attributes="value"
+      />
     </div>
 
   </form>

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+from pas.plugins.oidc.plugins import OIDCPlugin
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -7,7 +8,6 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.restapi.testing import RelativeSession
 from urllib.parse import urlparse
 from zope.component.hooks import setSite
-from pas.plugins.oidc.plugins import OIDCPlugin
 
 import pytest
 import requests
@@ -110,10 +110,7 @@ def google(restapi):
     portal = restapi["portal"]
     setSite(portal)
     with api.env.adopt_roles(["Manager", "Member"]):
-        portal.acl_users._setObject(
-            "google",
-            OIDCPlugin("google", "Google")
-        )
+        portal.acl_users._setObject("google", OIDCPlugin("google", "Google"))
 
     transaction.commit()
     yield portal

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -7,6 +7,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.restapi.testing import RelativeSession
 from urllib.parse import urlparse
 from zope.component.hooks import setSite
+from pas.plugins.oidc.plugins import OIDCPlugin
 
 import pytest
 import requests
@@ -102,3 +103,17 @@ def keycloak_login():
         return qs
 
     return func
+
+
+@pytest.fixture()
+def google(restapi):
+    portal = restapi["portal"]
+    setSite(portal)
+    with api.env.adopt_roles(["Manager", "Member"]):
+        portal.acl_users._setObject(
+            "google",
+            OIDCPlugin("google", "Google")
+        )
+
+    transaction.commit()
+    yield portal

--- a/tests/services/test_services_login_get.py
+++ b/tests/services/test_services_login_get.py
@@ -18,7 +18,7 @@ class TestServiceLoginGet:
             [0, "id", "oidc"],
             [0, "plugin", "oidc"],
             [0, "url", "/@login-oidc/oidc"],
-            [0, "title", "OIDC Authentication"],
+            [0, "title", "OIDC Connect"],
         ],
     )
     def test_login_get_options(self, idx: int, key: str, expected: str):

--- a/tests/services/test_services_login_get.py
+++ b/tests/services/test_services_login_get.py
@@ -18,7 +18,7 @@ class TestServiceLoginGet:
             [0, "id", "oidc"],
             [0, "plugin", "oidc"],
             [0, "url", "/@login-oidc/oidc"],
-            [0, "title", "OIDC Connect"],
+            [0, "title", "OpenID Connect"],
         ],
     )
     def test_login_get_options(self, idx: int, key: str, expected: str):

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -1,6 +1,4 @@
-from pas.plugins.oidc import PACKAGE_NAME
 from pas.plugins.oidc.plugins import OIDCPlugin
-from plone import api
 
 import pytest
 

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -1,6 +1,6 @@
 from pas.plugins.oidc import PACKAGE_NAME
-from plone import api
 from pas.plugins.oidc.plugins import OIDCPlugin
+from plone import api
 
 import pytest
 

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -1,0 +1,38 @@
+from pas.plugins.oidc import PACKAGE_NAME
+from plone import api
+from pas.plugins.oidc.plugins import OIDCPlugin
+
+import pytest
+
+
+class TestSetupInstall:
+    @pytest.fixture(autouse=True)
+    def _initialize(self, portal, api_anon_request):
+        self.portal = portal
+        self.api_session = api_anon_request
+        self.portal.acl_users._setObject('google', OIDCPlugin(id='google', title='Google'))
+
+    def test_login_get_available(self):
+        response = self.api_session.get("@login")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    @pytest.mark.parametrize(
+        "idx, key, expected",
+        [
+            [0, "id", "oidc"],
+            [0, "plugin", "oidc"],
+            [0, "url", "/@login-oidc/oidc"],
+            [0, "title", "OIDC Connect"],
+            [0, "id", "google"],
+            [0, "plugin", "oidc"],
+            [0, "url", "/@login-oidc/google"],
+            [0, "title", "Google"],
+        ],
+    )
+    def test_login_get_options(self, idx: int, key: str, expected: str):
+        response = self.api_session.get("@login")
+        data = response.json()
+        options = data["options"]
+        assert expected in options[idx][key]

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -1,16 +1,11 @@
-from pas.plugins.oidc.plugins import OIDCPlugin
-
 import pytest
 
 
 class TestSetupInstall:
     @pytest.fixture(autouse=True)
-    def _initialize(self, portal, api_anon_request):
-        self.portal = portal
+    def _initialize(self, google, api_anon_request):
+        self.portal = google
         self.api_session = api_anon_request
-        self.portal.acl_users._setObject(
-            "google", OIDCPlugin(id="google", title="Google")
-        )
 
     def test_login_get_available(self):
         response = self.api_session.get("@login")

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -10,7 +10,9 @@ class TestSetupInstall:
     def _initialize(self, portal, api_anon_request):
         self.portal = portal
         self.api_session = api_anon_request
-        self.portal.acl_users._setObject('google', OIDCPlugin(id='google', title='Google'))
+        self.portal.acl_users._setObject(
+            "google", OIDCPlugin(id="google", title="Google")
+        )
 
     def test_login_get_available(self):
         response = self.api_session.get("@login")

--- a/tests/services/test_servides_login_get_multiple_plugins.py
+++ b/tests/services/test_servides_login_get_multiple_plugins.py
@@ -26,11 +26,11 @@ class TestSetupInstall:
             [0, "id", "oidc"],
             [0, "plugin", "oidc"],
             [0, "url", "/@login-oidc/oidc"],
-            [0, "title", "OIDC Connect"],
-            [0, "id", "google"],
-            [0, "plugin", "oidc"],
-            [0, "url", "/@login-oidc/google"],
-            [0, "title", "Google"],
+            [0, "title", "OpenID Connect"],
+            [1, "id", "google"],
+            [1, "plugin", "oidc"],
+            [1, "url", "/@login-oidc/google"],
+            [1, "title", "Google"],
         ],
     )
     def test_login_get_options(self, idx: int, key: str, expected: str):

--- a/tests/utils/test_utils_flow.py
+++ b/tests/utils/test_utils_flow.py
@@ -10,7 +10,7 @@ class TestUtilsFlowStart:
     def _initialize(self, portal, http_request):
         self.portal = portal
         self.http_request = http_request
-        self.plugin = utils.get_plugin()
+        self.plugin = utils.get_plugins()[0]
 
     @pytest.fixture()
     def session_factory(self):


### PR DESCRIPTION
This way we can configure several OIDC providers in a given Plone site, just adding multiple OIDC plugins each one with its own configuration