### PR TITLE
Changes to make compatible with OAM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "plone.protect",
         "plone.restapi>=8.34.0",
         "oic",
+        "requests",
     ],
     extras_require={
         "test": [

--- a/src/pas/plugins/oidc/controlpanel/classic.py
+++ b/src/pas/plugins/oidc/controlpanel/classic.py
@@ -138,6 +138,13 @@ class OIDCControlPanelAdapter:
     def user_property_as_userid(self, value):
         self.settings.user_property_as_userid = value
 
+    @property
+    def identity_domain_name(self):
+        return self.settings.identity_domain_name
+
+    @identity_domain_name.setter
+    def identity_domain_name(self, value):
+        self.settings.identity_domain_name = value
 
 class OIDCSettingsForm(controlpanel.RegistryEditForm):
     schema = IOIDCSettings

--- a/src/pas/plugins/oidc/controlpanel/classic.py
+++ b/src/pas/plugins/oidc/controlpanel/classic.py
@@ -146,6 +146,7 @@ class OIDCControlPanelAdapter:
     def identity_domain_name(self, value):
         self.settings.identity_domain_name = value
 
+
 class OIDCSettingsForm(controlpanel.RegistryEditForm):
     schema = IOIDCSettings
     schema_prefix = "oidc_admin"

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -119,6 +119,13 @@ class IOIDCSettings(Interface):
         default="sub",
     )
 
+    identity_domain_name = schema.TextLine(
+        title=_("Identity Domain Name"),
+        description=_("Required for Oracle Authentication Manager only"),
+        required=False,
+        default="",
+    )
+
 
 class IOIDCControlpanel(IControlpanel):
     """OIDC Control panel"""

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -333,6 +333,8 @@ class OIDCPlugin(BasePlugin):
     def get_oauth2_client(self):
         try:
             client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
+            client.allow["issuer_mismatch"] = True  # Some providers aren't configured with configured and issuer urls the same even though they should.
+
             # registration_response = client.register(provider_info["registration_endpoint"], redirect_uris=...)
             # ... oic.exception.RegistrationError: {'error': 'insufficient_scope',
             #     'error_description': "Policy 'Trusted Hosts' rejected request to client-registration service. Details: Host not trusted."}

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -167,7 +167,7 @@ class OIDCPlugin(BasePlugin):
             id="identity_domain_name",
             type="string",
             mode="w",
-            label="Required for Oracle Authentication Manager",
+            label="Required for Oracle Authentication Manager only",
         ),
     )
 

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -73,8 +73,13 @@ class IOIDCPlugin(Interface):
 
 class OAMClient(Client):
     """ Override so we can adjust the jwks_uri to add param needed for OAM """
+
+    def __init__(self, *args, domain=None, **xargs):
+        self.domain = domain
+        return super().__init__(self, *args, **xargs)
+    
     def handle_provider_config(self, pcr, issuer, keys=True, endpoints=True):
-        domain = self.settings.domain
+        domain = self.domain
         if domain:
             # TODO: we need to modify jwks_uri in the provider_info to add the identityDomain for OAM
             # gets used in https://github.com/CZ-NIC/pyoidc/blob/0bd1eadcefc5ccb7ef6c69d9b631537a7d3cfe30/src/oic/oauth2/__init__.py#L1132
@@ -365,12 +370,11 @@ class OIDCPlugin(BasePlugin):
             session = requests.Session()
             session.headers.update({"x-oauth-identity-domain-name": domain})
             settings.requests_session = session
-            settings.domain = domain # Used just by us
         else:
             settings = None
         try:
             if domain:
-                client = OAMClient(client_authn_method=CLIENT_AUTHN_METHOD, settings=settings)
+                client = OAMClient(client_authn_method=CLIENT_AUTHN_METHOD, settings=settings, domain=domain)
             else:
                 client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
             client.allow["issuer_mismatch"] = (

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -2,6 +2,7 @@ from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
 from contextlib import contextmanager
 from oic.oic import Client
+from oic.oic.settings import ClientSettings
 from oic.oic.message import OpenIDSchema
 from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
@@ -28,6 +29,7 @@ from zope.interface import Interface
 import itertools
 import plone.api as api
 import string
+import requests
 
 
 manage_addOIDCPluginForm = PageTemplateFile(
@@ -159,6 +161,12 @@ class OIDCPlugin(BasePlugin):
             type="string",
             mode="w",
             label="User info property used as userid, default 'sub'",
+        ),
+        dict(
+            id="identity_domain_name",
+            type="string",
+            mode="w",
+            label="Required for Oracle Authentication Manager",
         ),
     )
 
@@ -331,8 +339,16 @@ class OIDCPlugin(BasePlugin):
 
     # TODO: memoize (?)
     def get_oauth2_client(self):
+        domain = self.getProperty("identity_domain_name")
+        if domain:
+            settings = ClientSettings()
+            session = requests.Session()
+            session.headers.update({'x-oauth-identity-domain-name': domain})
+            settings.requests_session = session
+        else:
+            settings = None
         try:
-            client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
+            client = Client(client_authn_method=CLIENT_AUTHN_METHOD, settings=settings)
             client.allow["issuer_mismatch"] = True  # Some providers aren't configured with configured and issuer urls the same even though they should.
 
             # registration_response = client.register(provider_info["registration_endpoint"], redirect_uris=...)
@@ -341,6 +357,16 @@ class OIDCPlugin(BasePlugin):
 
             # use WebFinger
             provider_info = client.provider_config(self.getProperty("issuer"))  # noqa
+            if domain:
+                # TODO: we need to modify jwks_uri in the provider_info to add the identityDomain for OAM
+                # gets used in https://github.com/CZ-NIC/pyoidc/blob/0bd1eadcefc5ccb7ef6c69d9b631537a7d3cfe30/src/oic/oauth2/__init__.py#L1132
+                # we could
+                # - override client.handle_provider_info to change jwks_uri. - https://github.com/CZ-NIC/pyoidc/blob/0bd1eadcefc5ccb7ef6c69d9b631537a7d3cfe30/src/oic/oauth2/__init__.py#L1055
+                # - monkey patch KeyBundle and modify source - https://github.com/CZ-NIC/pyoidc/blob/master/src/oic/utils/keyio.py#L66
+                # - modify the keybundle objects after provider_config but before they are used.
+                #   - client.keyjar.issuer_keys[issuer].source = ...
+                jwks_uri = client.keyjar.issuer_keys[self.getProperty("issuer")].source
+                client.keyjar.issuer_keys[self.getProperty("issuer")].source = f'{jwks_uri}?identityDomainName={domain}'
             info = {
                 "client_id": self.getProperty("client_id"),
                 "client_secret": self.getProperty("client_secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -370,7 +370,8 @@ class OIDCPlugin(BasePlugin):
                 #   - client.keyjar.issuer_keys[issuer].source = ...
                 for key in client.keyjar.issuer_keys[self.getProperty("issuer")]:
                     req = requests.PreparedRequest()
-                    key.source = req.prepare_url(key.source, dict(identityDomainName=domain)).url
+                    req.prepare_url(key.source, dict(identityDomainName=domain))
+                    key.source = req.url
             info = {
                 "client_id": self.getProperty("client_id"),
                 "client_secret": self.getProperty("client_secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -5,7 +5,6 @@ from oic.oic import Client
 from oic.oic.message import OpenIDSchema
 from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
-from oic.utils.settings import ClientSettings
 from pas.plugins.oidc import logger
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
@@ -72,7 +71,7 @@ class IOIDCPlugin(Interface):
 
 
 class OAMClient(Client):
-    """Override so we can adjust the jwks_uri to add param needed for OAM"""
+    """Override so we can adjust the jwks_uri to add domain needed for OAM"""
 
     def __init__(self, *args, domain=None, **xargs):
         super().__init__(self, *args, **xargs)
@@ -85,13 +84,8 @@ class OAMClient(Client):
     def handle_provider_config(self, pcr, issuer, keys=True, endpoints=True):
         domain = self.domain
         if domain:
-            # TODO: we need to modify jwks_uri in the provider_info to add the identityDomain for OAM
+            # we need to modify jwks_uri in the provider_info to add the identityDomain for OAM
             # gets used in https://github.com/CZ-NIC/pyoidc/blob/0bd1eadcefc5ccb7ef6c69d9b631537a7d3cfe30/src/oic/oauth2/__init__.py#L1132
-            # we could
-            # - override client.handle_provider_info to change jwks_uri. - https://github.com/CZ-NIC/pyoidc/blob/0bd1eadcefc5ccb7ef6c69d9b631537a7d3cfe30/src/oic/oauth2/__init__.py#L1055
-            # - monkey patch KeyBundle and modify source - https://github.com/CZ-NIC/pyoidc/blob/master/src/oic/utils/keyio.py#L66
-            # - modify the keybundle objects after provider_config but before they are used.
-            #   - client.keyjar.issuer_keys[issuer].source = ...
             url = pcr["jwks_uri"]
             req = requests.PreparedRequest()
             req.prepare_url(url, dict(identityDomainName=domain))

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -2,10 +2,10 @@ from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
 from contextlib import contextmanager
 from oic.oic import Client
-from oic.oic.settings import ClientSettings
 from oic.oic.message import OpenIDSchema
 from oic.oic.message import RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+from oic.utils.settings import ClientSettings
 from pas.plugins.oidc import logger
 from plone.base.utils import safe_text
 from plone.protect.utils import safeWrite
@@ -28,8 +28,8 @@ from zope.interface import Interface
 
 import itertools
 import plone.api as api
-import string
 import requests
+import string
 
 
 manage_addOIDCPluginForm = PageTemplateFile(
@@ -343,13 +343,15 @@ class OIDCPlugin(BasePlugin):
         if domain:
             settings = ClientSettings()
             session = requests.Session()
-            session.headers.update({'x-oauth-identity-domain-name': domain})
+            session.headers.update({"x-oauth-identity-domain-name": domain})
             settings.requests_session = session
         else:
             settings = None
         try:
             client = Client(client_authn_method=CLIENT_AUTHN_METHOD, settings=settings)
-            client.allow["issuer_mismatch"] = True  # Some providers aren't configured with configured and issuer urls the same even though they should.
+            client.allow["issuer_mismatch"] = (
+                True  # Some providers aren't configured with configured and issuer urls the same even though they should.
+            )
 
             # registration_response = client.register(provider_info["registration_endpoint"], redirect_uris=...)
             # ... oic.exception.RegistrationError: {'error': 'insufficient_scope',
@@ -366,7 +368,9 @@ class OIDCPlugin(BasePlugin):
                 # - modify the keybundle objects after provider_config but before they are used.
                 #   - client.keyjar.issuer_keys[issuer].source = ...
                 jwks_uri = client.keyjar.issuer_keys[self.getProperty("issuer")].source
-                client.keyjar.issuer_keys[self.getProperty("issuer")].source = f'{jwks_uri}?identityDomainName={domain}'
+                client.keyjar.issuer_keys[self.getProperty("issuer")].source = (
+                    f"{jwks_uri}?identityDomainName={domain}"
+                )
             info = {
                 "client_id": self.getProperty("client_id"),
                 "client_secret": self.getProperty("client_secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -368,10 +368,8 @@ class OIDCPlugin(BasePlugin):
                 # - monkey patch KeyBundle and modify source - https://github.com/CZ-NIC/pyoidc/blob/master/src/oic/utils/keyio.py#L66
                 # - modify the keybundle objects after provider_config but before they are used.
                 #   - client.keyjar.issuer_keys[issuer].source = ...
-                jwks_uri = client.keyjar.issuer_keys[self.getProperty("issuer")].source
-                client.keyjar.issuer_keys[self.getProperty("issuer")].source = (
-                    f"{jwks_uri}?identityDomainName={domain}"
-                )
+                for key in client.keyjar.issuer_keys[self.getProperty("issuer")]:
+                    key.source = requests.PreparedRequest().prepare_request(key.source, dict(identityDomainName=domain)).url
             info = {
                 "client_id": self.getProperty("client_id"),
                 "client_secret": self.getProperty("client_secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -369,7 +369,8 @@ class OIDCPlugin(BasePlugin):
                 # - modify the keybundle objects after provider_config but before they are used.
                 #   - client.keyjar.issuer_keys[issuer].source = ...
                 for key in client.keyjar.issuer_keys[self.getProperty("issuer")]:
-                    key.source = requests.PreparedRequest().prepare_request(key.source, dict(identityDomainName=domain)).url
+                    req = requests.PreparedRequest()
+                    key.source = req.prepare_url(key.source, dict(identityDomainName=domain)).url
             info = {
                 "client_id": self.getProperty("client_id"),
                 "client_secret": self.getProperty("client_secret"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -167,7 +167,7 @@ class OIDCPlugin(BasePlugin):
             id="identity_domain_name",
             type="string",
             mode="w",
-            label="Required for Oracle Authentication Manager only",
+            label="Identity Domain Name (required for Oracle Authentication Manager only)",
         ),
     )
 

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -94,6 +94,7 @@ class OIDCPlugin(BasePlugin):
     use_deprecated_redirect_uri_for_logout = False
     use_modified_openid_schema = False
     user_property_as_userid = "sub"
+    identity_domain_name = ""
 
     _properties = (
         dict(id="title", type="string", mode="w", label="Title"),

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -72,12 +72,12 @@ class IOIDCPlugin(Interface):
 
 
 class OAMClient(Client):
-    """ Override so we can adjust the jwks_uri to add param needed for OAM """
+    """Override so we can adjust the jwks_uri to add param needed for OAM"""
 
     def __init__(self, *args, domain=None, **xargs):
         self.domain = domain
         return super().__init__(self, *args, **xargs)
-    
+
     def handle_provider_config(self, pcr, issuer, keys=True, endpoints=True):
         domain = self.domain
         if domain:
@@ -88,10 +88,10 @@ class OAMClient(Client):
             # - monkey patch KeyBundle and modify source - https://github.com/CZ-NIC/pyoidc/blob/master/src/oic/utils/keyio.py#L66
             # - modify the keybundle objects after provider_config but before they are used.
             #   - client.keyjar.issuer_keys[issuer].source = ...
-            url = pcr['jwks_uri']
+            url = pcr["jwks_uri"]
             req = requests.PreparedRequest()
             req.prepare_url(url, dict(identityDomainName=domain))
-            pcr['jwks_uri'] = req.url
+            pcr["jwks_uri"] = req.url
         return super().handle_provider_config(pcr, issuer, keys, endpoints)
 
 
@@ -374,7 +374,11 @@ class OIDCPlugin(BasePlugin):
             settings = None
         try:
             if domain:
-                client = OAMClient(client_authn_method=CLIENT_AUTHN_METHOD, settings=settings, domain=domain)
+                client = OAMClient(
+                    client_authn_method=CLIENT_AUTHN_METHOD,
+                    settings=settings,
+                    domain=domain,
+                )
             else:
                 client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
             client.allow["issuer_mismatch"] = (

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -128,7 +128,7 @@ def authorization_flow_args(plugin: plugins.OIDCPlugin, session: Session) -> dic
         "redirect_uri": plugin.get_redirect_uris(),
     }
     if plugin.getProperty("identity_domain_name"):
-        args['domain'] = plugin.getProperty("identity_domain_name", "")
+        args["domain"] = plugin.getProperty("identity_domain_name", "")
     if plugin.getProperty("use_pkce"):
         # Build a random string of 43 to 128 characters
         # and send it in the request as a base64-encoded urlsafe string of the sha256 hash of that string

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -127,6 +127,8 @@ def authorization_flow_args(plugin: plugins.OIDCPlugin, session: Session) -> dic
         "nonce": session.get("nonce"),
         "redirect_uri": plugin.get_redirect_uris(),
     }
+    if plugin.getProperty("identity_domain_name"):
+        args['domain'] = plugin.getProperty("identity_domain_name", "")
     if plugin.getProperty("use_pkce"):
         # Build a random string of 43 to 128 characters
         # and send it in the request as a base64-encoded urlsafe string of the sha256 hash of that string

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -23,6 +23,7 @@ def keycloak(keycloak_service):
         "scope": ("openid", "profile", "email"),
         "redirect_uris": ("/login_oidc/oidc",),
         "create_restapi_ticket": True,
+        "identity_domain_name": "blah",  # ensure non OAM SP ignores extra params/header
     }
 
 


### PR DESCRIPTION
- **set client.allow["issuer_mismatch"] = True to make more compatible**
  - this is tested. decided to use for all since it shouldn't make a difference to non OAM?
- **add in changes to make work with OAM**
  - [x] new advanced setting for identity_domain_name which is used as a param and header which OAM needs apparently 
  - [x] add header
  - [x] add extra params
  - [x] test against live OAM
