### PR TITLE
back channel logout

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -10,7 +10,7 @@ codespell_skip = "*.min.js,*.pot,*.po,*.yaml,*.json"
 codespell_ignores = "vew"
 dependencies_ignores = "['plone.restapi', 'plone.volto', 'zestreleaser.towncrier', 'zest.releaser', 'pytest', 'pytest-cov', 'pytest-plone', 'pytest-docker', 'pytest-vcr', 'pytest-mock', 'gocept.pytestlayer', 'requests-mock', 'vcrpy']"
 dependencies_mappings = [
-    "Plone = ['Products.CMFPlone', 'Products.CMFCore', 'Products.GenericSetup', 'Products.PluggableAuthService', 'Products.PlonePAS']",
+    "Plone = ['Products.CMFPlone', 'Products.CMFCore', 'Products.GenericSetup', 'Products.PluggableAuthService', 'Products.PlonePAS', 'plone.keyring']",
     ]
 check_manifest_ignores = """
     "news/*",

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ifeq ($(PYTHON_VERSION_OK),0)
 endif
 
 all: build
+build: install
 
 # Add the following 'help' target to your Makefile
 # And add help text after each target name starting with '\#\#'

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Currently, the Plone logout form is unchanged.
 Instead, for testing go to the logout page of the plugin: http://localhost:8080/Plone/acl_users/oidc/logout,
 this will take you to Keycloak to logout, and then return to the post-logout redirect URL.
 
-#### Experimental backchannel SLO (experimental)
+#### Backchannel SLO (experimental)
 
 OIDC Backchannel Logout is a server-to-server mechanism where the IdP notifies RPs via an HTTP POST request to terminate user sessions upon logout, ensuring secure and seamless Single Logout (SLO) without relying on the user's browser.
 See the specification [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html).

--- a/README.md
+++ b/README.md
@@ -213,6 +213,19 @@ Currently, the Plone logout form is unchanged.
 Instead, for testing go to the logout page of the plugin: http://localhost:8080/Plone/acl_users/oidc/logout,
 this will take you to Keycloak to logout, and then return to the post-logout redirect URL.
 
+#### Experimental backchannel SLO (experimental)
+
+OIDC Backchannel Logout is a server-to-server mechanism where the IdP notifies RPs via an HTTP POST request to terminate user sessions upon logout, ensuring secure and seamless Single Logout (SLO) without relying on the user's browser.
+See the specification [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html).
+
+Current backchannel logout implementation, in this product, utilizes functionality introduced in plone.session >= 4.0.0 (Plone 6 and later) for server-side session invalidation (see plone.session PR [plone.session#26](https://github.com/plone/plone.session/pull/26)), and, at the moment, applies only to Plone Classic UI.
+
+To enable this functionality:
+
+1. Navigate to `.../acl_users/session/manage_secret` and enable the `Enable per-user keyring` option.
+
+2. Configure the OpenID Provider (e.g., Keycloak) to use the backchannel logout endpoint with the url: `.../acl_users/oidc/backchannel-logout`
+
 ## Technical Decisions
 
 ### Usage of sessions in the login process

--- a/news/67.feature
+++ b/news/67.feature
@@ -1,0 +1,1 @@
+Add backchannel logout implementation for classic ui session @mamico 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ Zope = [
 ]
 python-dateutil = ['dateutil']
 ignore-packages = ['plone.restapi', 'plone.volto', 'zestreleaser.towncrier', 'zest.releaser', 'pytest', 'pytest-cov', 'pytest-plone', 'pytest-docker', 'pytest-vcr', 'pytest-mock', 'zope.pytestlayer', 'requests-mock', 'vcrpy']
-Plone = ['Products.CMFPlone', 'Products.CMFCore', 'Products.GenericSetup', 'Products.PluggableAuthService', 'Products.PlonePAS']
+Plone = ['Products.CMFPlone', 'Products.CMFCore', 'Products.GenericSetup', 'Products.PluggableAuthService', 'Products.PlonePAS', 'plone.keyring']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
--e ".[test]"
+-e .[test]

--- a/src/pas/plugins/oidc/browser/configure.zcml
+++ b/src/pas/plugins/oidc/browser/configure.zcml
@@ -37,4 +37,12 @@
       layer="pas.plugins.oidc.interfaces.IPasPluginsOidcLayer"
       />
 
+  <browser:page
+      name="backchannel-logout"
+      for="pas.plugins.oidc.plugins.IOIDCPlugin"
+      class=".view.BackChannelLogoutView"
+      permission="zope2.View"
+      layer="pas.plugins.oidc.interfaces.IPasPluginsOidcLayer"
+      />
+
 </configure>


### PR DESCRIPTION
OIDC Backchannel Logout is a server-to-server mechanism where the IdP notifies RPs via an HTTP POST request to terminate user sessions upon logout, ensuring secure and seamless Single Logout (SLO) without relying on the user's browser.
See the specification [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html).

Current backchannel logout implementation, in this product, utilizes functionality introduced in plone.session >= 4.0.0 (Plone 6 and later) for server-side session invalidation (see plone.session PR [plone.session#26](https://github.com/plone/plone.session/pull/26)), and, at the moment, applies only to Plone Classic UI.

To enable this functionality:

1. Navigate to `.../acl_users/session/manage_secret` and enable the `Enable per-user keyring` option.

2. Configure the OpenID Provider (e.g., Keycloak) to use the backchannel logout endpoint with the url: `.../acl_users/oidc/backchannel-logout`