### PR TITLE
fix venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ requirements-mxdev.txt: ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
-	@uv venv $(VENV_FOLDER)
+	@uv venv $(VENV_FOLDER) --clear
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync


### PR DESCRIPTION
Try to fix GHA failures like

https://github.com/collective/pas.plugins.oidc/actions/runs/23942281322/job/69830994448

```
+ echo '==> Install environment'
+ uv venv /home/runner/work/pas.plugins.oidc/pas.plugins.oidc/.venv
==> Install environment
Using CPython 3.10.20
Creating virtual environment at: .venv
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/home/runner/work/pas.plugins.oidc/pas.plugins.oidc/.venv`. Use `--clear` to replace it
make: *** [Makefile:76: /home/runner/work/pas.plugins.oidc/pas.plugins.oidc/.venv] Error 2
Error: Process completed with exit code 2.

```