### PR TITLE
allow user info schema customization

### DIFF
--- a/news/88.feature
+++ b/news/88.feature
@@ -1,1 +1,1 @@
-make user_info openidschema extensible via json field
+make user_info openidschema extensible

--- a/news/88.feature
+++ b/news/88.feature
@@ -1,0 +1,1 @@
+make user_info openidschema extensible via json field

--- a/src/pas/plugins/oidc/browser/view.py
+++ b/src/pas/plugins/oidc/browser/view.py
@@ -120,14 +120,18 @@ class CallbackView(BrowserView):
         )
         method = self.context.getProperty("userinfo_endpoint_method", "POST")
         if self.context.getProperty("use_modified_openid_schema"):
-            IdToken.c_param.update({
-                "email_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
-                "phone_number_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
-            })
+            IdToken.c_param.update(
+                {
+                    "email_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                    "phone_number_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                }
+            )
 
         # The response you get back is an instance of an AccessTokenResponse
         # or again possibly an ErrorResponse instance.
-        user_info = utils.get_user_info(client, state, args, method)
+        user_info = utils.get_user_info(
+            client, state, args, method, utils.extend_user_info_schema(self.context)
+        )
         if user_info:
             self.context.rememberIdentity(user_info)
             self.request.response.setHeader(

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -1,48 +1,16 @@
 """Module where all interfaces, events and exceptions live."""
 
-import json
 from pas.plugins.oidc import _
 from plone.restapi.controlpanels.interfaces import IControlpanel
 from zope import schema
-from zope.interface import Interface, Invalid
+from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
-from plone.schema import JSONField
+
+from pas.plugins.oidc.utils import validate_userinfo_schema_extension
 
 
 class IPasPluginsOidcLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
-
-
-def validate_userinfo_schema_extension(values):
-    valid_types = [
-        "SINGLE_REQUIRED_STRING",
-        "SINGLE_OPTIONAL_STRING",
-        "SINGLE_OPTIONAL_INT",
-        "OPTIONAL_LIST_OF_STRINGS",
-        "REQUIRED_LIST_OF_STRINGS",
-        "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
-        "REQUIRED_LIST_OF_SP_SEP_STRINGS",
-        "SINGLE_OPTIONAL_JSON",
-    ]
-
-    for value in values:
-        split_value = value.split(":")
-        if len(split_value) > 2 or len(split_value) < 2:
-            raise Invalid(
-                _(
-                    "invalid userinfo_schema_extensions",
-                    f"A line can only consist of <key>:<type>. {values} is given",
-                )
-            )
-        if split_value[1] not in valid_types:
-            raise Invalid(
-                _(
-                    "invalid userinfo_schema_extensions",
-                    f"Type {split_value[1]} not valid for {split_value[0]}",
-                )
-            )
-
-    return True
 
 
 class IOIDCSettings(Interface):
@@ -177,32 +145,6 @@ class IOIDCSettings(Interface):
         default="POST",
     )
 
-    # userinfo_schema_extensions = JSONField(
-    #     title=_("Userinfo Schema extension"),
-    #     description=_(
-    #         "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)"
-    #     ),
-    #     schema=json.dumps(
-    #         {
-    #             "type": "object",
-    #             "patternProperties": {
-    #                 "^.*$": {
-    #                     "type": "string",
-    #                     "enum": [
-    #                         "SINGLE_REQUIRED_STRING",
-    #                         "SINGLE_OPTIONAL_STRING",
-    #                         "SINGLE_OPTIONAL_INT",
-    #                         "OPTIONAL_LIST_OF_STRINGS",
-    #                         "REQUIRED_LIST_OF_STRINGS",
-    #                         "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
-    #                         "REQUIRED_LIST_OF_SP_SEP_STRINGS",
-    #                         "SINGLE_OPTIONAL_JSON",
-    #                     ],
-    #                 }
-    #             },
-    #         }
-    #     ),
-    # )
     userinfo_schema_extensions = schema.List(
         title=_("Userinfo Schema extension"),
         description=_(

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -13,6 +13,36 @@ class IPasPluginsOidcLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
 
 
+def validate_userinfo_schema_extension(values):
+    valid_types = [
+        "SINGLE_REQUIRED_STRING",
+        "SINGLE_OPTIONAL_STRING",
+        "SINGLE_OPTIONAL_INT",
+        "OPTIONAL_LIST_OF_STRINGS",
+        "REQUIRED_LIST_OF_STRINGS",
+        "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
+        "REQUIRED_LIST_OF_SP_SEP_STRINGS",
+        "SINGLE_OPTIONAL_JSON",
+    ]
+
+    for value in values:
+        split_value = value.split(":")
+        if len(split_value) > 2 or len(split_value) < 2:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"A line can only consist of <key>:<type>. {values} is given",
+                )
+            )
+        if split_value[1] not in valid_types:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"Type {split_value[1]} not valid for {split_value[0]}",
+                )
+            )
+
+
 class IOIDCSettings(Interface):
     """OIDC plugin settings"""
 
@@ -184,36 +214,6 @@ class IOIDCSettings(Interface):
         default=[],
         constraint=validate_userinfo_schema_extension,
     )
-
-
-def validate_userinfo_schema_extension(values):
-    valid_types = [
-        "SINGLE_REQUIRED_STRING",
-        "SINGLE_OPTIONAL_STRING",
-        "SINGLE_OPTIONAL_INT",
-        "OPTIONAL_LIST_OF_STRINGS",
-        "REQUIRED_LIST_OF_STRINGS",
-        "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
-        "REQUIRED_LIST_OF_SP_SEP_STRINGS",
-        "SINGLE_OPTIONAL_JSON",
-    ]
-
-    for value in values:
-        split_value = value.split(":")
-        if len(split_value) > 2 or len(split_value) < 2:
-            raise Invalid(
-                _(
-                    "invalid userinfo_schema_extensions",
-                    f"A line can only consist of <key>:<type>. {values} is given",
-                )
-            )
-        if split_value[1] not in valid_types:
-            raise Invalid(
-                _(
-                    "invalid userinfo_schema_extensions",
-                    f"Type {split_value[1]} not valid for {split_value[0]}",
-                )
-            )
 
 
 class IOIDCControlpanel(IControlpanel):

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -4,7 +4,7 @@ import json
 from pas.plugins.oidc import _
 from plone.restapi.controlpanels.interfaces import IControlpanel
 from zope import schema
-from zope.interface import Interface
+from zope.interface import Interface, Invalid
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from plone.schema import JSONField
 
@@ -145,32 +145,75 @@ class IOIDCSettings(Interface):
         default="POST",
     )
 
-    userinfo_schema_extensions = JSONField(
+    # userinfo_schema_extensions = JSONField(
+    #     title=_("Userinfo Schema extension"),
+    #     description=_(
+    #         "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)"
+    #     ),
+    #     schema=json.dumps(
+    #         {
+    #             "type": "object",
+    #             "patternProperties": {
+    #                 "^.*$": {
+    #                     "type": "string",
+    #                     "enum": [
+    #                         "SINGLE_REQUIRED_STRING",
+    #                         "SINGLE_OPTIONAL_STRING",
+    #                         "SINGLE_OPTIONAL_INT",
+    #                         "OPTIONAL_LIST_OF_STRINGS",
+    #                         "REQUIRED_LIST_OF_STRINGS",
+    #                         "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
+    #                         "REQUIRED_LIST_OF_SP_SEP_STRINGS",
+    #                         "SINGLE_OPTIONAL_JSON",
+    #                     ],
+    #                 }
+    #             },
+    #         }
+    #     ),
+    # )
+    userinfo_schema_extensions = schema.List(
         title=_("Userinfo Schema extension"),
         description=_(
-            "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)"
+            "Mapping of user schema fields to how they should be parsed. One line for each key. Each line should be <key>:<type>. types are: SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON."
         ),
-        schema=json.dumps(
-            {
-                "type": "object",
-                "patternProperties": {
-                    "^.*$": {
-                        "type": "string",
-                        "enum": [
-                            "SINGLE_REQUIRED_STRING",
-                            "SINGLE_OPTIONAL_STRING",
-                            "SINGLE_OPTIONAL_INT",
-                            "OPTIONAL_LIST_OF_STRINGS",
-                            "REQUIRED_LIST_OF_STRINGS",
-                            "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
-                            "REQUIRED_LIST_OF_SP_SEP_STRINGS",
-                            "SINGLE_OPTIONAL_JSON",
-                        ],
-                    }
-                },
-            }
+        value_type=schema.TextLine(
+            title=_("User Claim"),
+            description=_(""),
         ),
+        required=False,
+        default=[],
+        constraint=validate_userinfo_schema_extension,
     )
+
+
+def validate_userinfo_schema_extension(values):
+    valid_types = [
+        "SINGLE_REQUIRED_STRING",
+        "SINGLE_OPTIONAL_STRING",
+        "SINGLE_OPTIONAL_INT",
+        "OPTIONAL_LIST_OF_STRINGS",
+        "REQUIRED_LIST_OF_STRINGS",
+        "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
+        "REQUIRED_LIST_OF_SP_SEP_STRINGS",
+        "SINGLE_OPTIONAL_JSON",
+    ]
+
+    for value in values:
+        split_value = value.split(":")
+        if len(split_value) > 2 or len(split_value) < 2:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"A line can only consist of <key>:<type>. {values} is given",
+                )
+            )
+        if split_value[1] not in valid_types:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"Type {split_value[1]} not valid for {split_value[0]}",
+                )
+            )
 
 
 class IOIDCControlpanel(IControlpanel):

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -1,10 +1,12 @@
 """Module where all interfaces, events and exceptions live."""
 
+import json
 from pas.plugins.oidc import _
 from plone.restapi.controlpanels.interfaces import IControlpanel
 from zope import schema
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from plone.schema import JSONField
 
 
 class IPasPluginsOidcLayer(IDefaultBrowserLayer):
@@ -141,6 +143,33 @@ class IOIDCSettings(Interface):
         description=_("HTTP Method to use for the userinfo endpoint"),
         values=["GET", "POST"],
         default="POST",
+    )
+
+    userinfo_schema_extensions = JSONField(
+        title=_("Userinfo Schema extension"),
+        description=_(
+            "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)"
+        ),
+        schema=json.dumps(
+            {
+                "type": "object",
+                "patternProperties": {
+                    "^.*$": {
+                        "type": "string",
+                        "enum": [
+                            "SINGLE_REQUIRED_STRING",
+                            "SINGLE_OPTIONAL_STRING",
+                            "SINGLE_OPTIONAL_INT",
+                            "OPTIONAL_LIST_OF_STRINGS",
+                            "REQUIRED_LIST_OF_STRINGS",
+                            "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
+                            "REQUIRED_LIST_OF_SP_SEP_STRINGS",
+                            "SINGLE_OPTIONAL_JSON",
+                        ],
+                    }
+                },
+            }
+        ),
     )
 
 

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -42,7 +42,7 @@ def validate_userinfo_schema_extension(values):
                 )
             )
 
-    return values
+    return True
 
 
 class IOIDCSettings(Interface):

--- a/src/pas/plugins/oidc/interfaces.py
+++ b/src/pas/plugins/oidc/interfaces.py
@@ -42,6 +42,8 @@ def validate_userinfo_schema_extension(values):
                 )
             )
 
+    return values
+
 
 class IOIDCSettings(Interface):
     """OIDC plugin settings"""

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -128,7 +128,7 @@ class OIDCPlugin(BasePlugin):
     identity_domain_name: str = ""
     userinfo_endpoint_method: str = "POST"
     userinfo_endpoint_method_values: tuple[str, ...] = ("GET", "POST")
-    userinfo_schema_extensions: str = ""
+    userinfo_schema_extensions: tuple[str] = []
 
     _properties: tuple[dict] = (
         {"id": "title", "type": "string", "mode": "w", "label": "Title"},

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -235,7 +235,7 @@ class OIDCPlugin(BasePlugin):
         },
         {
             "id": "userinfo_schema_extensions",
-            "type": "string",
+            "type": "lines",
             "mode": "w",
             "label": "Userinfo Schema Extension",
         },

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -237,10 +237,7 @@ class OIDCPlugin(BasePlugin):
             "id": "userinfo_schema_extensions",
             "type": "string",
             "mode": "w",
-            "label": (
-                "Userinfo Schema Extension"
-                "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)",
-            ),
+            "label": "Userinfo Schema Extension",
         },
     )
 

--- a/src/pas/plugins/oidc/plugins.py
+++ b/src/pas/plugins/oidc/plugins.py
@@ -32,7 +32,6 @@ import plone.api as api
 import requests
 import string
 
-
 manage_addOIDCPluginForm = PageTemplateFile(
     "www/oidcPluginForm", globals(), __name__="manage_addOIDCPluginForm"
 )
@@ -129,6 +128,7 @@ class OIDCPlugin(BasePlugin):
     identity_domain_name: str = ""
     userinfo_endpoint_method: str = "POST"
     userinfo_endpoint_method_values: tuple[str, ...] = ("GET", "POST")
+    userinfo_schema_extensions: str = ""
 
     _properties: tuple[dict] = (
         {"id": "title", "type": "string", "mode": "w", "label": "Title"},
@@ -231,6 +231,15 @@ class OIDCPlugin(BasePlugin):
             "label": (
                 "Userinfo Endpoint Method "
                 "(HTTP Method to use for the userinfo endpoint)"
+            ),
+        },
+        {
+            "id": "userinfo_schema_extensions",
+            "type": "string",
+            "mode": "w",
+            "label": (
+                "Userinfo Schema Extension"
+                "Mapping of user schema fields to how they should be parsed (SINGLE_REQUIRED_STRING, SINGLE_OPTIONAL_STRING, SINGLE_OPTIONAL_INT, OPTIONAL_LIST_OF_STRINGS, REQUIRED_LIST_OF_STRINGS, OPTIONAL_LIST_OF_SP_SEP_STRINGS, REQUIRED_LIST_OF_SP_SEP_STRINGS, SINGLE_OPTIONAL_JSON)",
             ),
         },
     )

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -205,13 +205,6 @@ class Post(LoginOIDC):
         qs = qs[1:] if qs.startswith("?") else qs
         args, state = utils.parse_authorization_response(plugin, qs, client, session)
         method = plugin.getProperty("userinfo_endpoint_method", "POST")
-        try:
-            userinfo_schema_extensions = json.loads(
-                plugin.getProperty("userinfo_schema_extensions", "")
-            )
-        except json.JSONDecodeError as e:
-            logger.error(e)
-            userinfo_schema_extensions = None
 
         if plugin.getProperty("use_modified_openid_schema"):
             IdToken.c_param.update(
@@ -224,7 +217,7 @@ class Post(LoginOIDC):
         # The response you get back is an instance of an AccessTokenResponse
         # or again possibly an ErrorResponse instance.
         user_info = utils.get_user_info(
-            client, state, args, method, userinfo_schema_extensions
+            client, state, args, method, utils.extend_user_info_schema(plugin)
         )
         if user_info:
             alsoProvides(self.request, IDisableCSRFProtection)

--- a/src/pas/plugins/oidc/services/oidc/oidc.py
+++ b/src/pas/plugins/oidc/services/oidc/oidc.py
@@ -1,3 +1,4 @@
+import json
 from oic.oic.message import EndSessionRequest
 from oic.oic.message import IdToken
 from pas.plugins.oidc import _
@@ -204,15 +205,27 @@ class Post(LoginOIDC):
         qs = qs[1:] if qs.startswith("?") else qs
         args, state = utils.parse_authorization_response(plugin, qs, client, session)
         method = plugin.getProperty("userinfo_endpoint_method", "POST")
+        try:
+            userinfo_schema_extensions = json.loads(
+                plugin.getProperty("userinfo_schema_extensions", "")
+            )
+        except json.JSONDecodeError as e:
+            logger.error(e)
+            userinfo_schema_extensions = None
+
         if plugin.getProperty("use_modified_openid_schema"):
-            IdToken.c_param.update({
-                "email_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
-                "phone_number_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
-            })
+            IdToken.c_param.update(
+                {
+                    "email_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                    "phone_number_verified": utils.SINGLE_OPTIONAL_BOOLEAN_AS_STRING,
+                }
+            )
 
         # The response you get back is an instance of an AccessTokenResponse
         # or again possibly an ErrorResponse instance.
-        user_info = utils.get_user_info(client, state, args, method)
+        user_info = utils.get_user_info(
+            client, state, args, method, userinfo_schema_extensions
+        )
         if user_info:
             alsoProvides(self.request, IDisableCSRFProtection)
             action = "login"

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -186,15 +186,9 @@ def parse_authorization_response(
 
 def extend_user_info_schema(plugin) -> type[message.OpenIDSchema]:
 
-    try:
-        userinfo_schema_extensions = json.loads(
-            plugin.getProperty("userinfo_schema_extensions", "{}")
-        )
-    except json.JSONDecodeError as e:
-        logger.error(e)
-        return message.OpenIDSchema
+    userinfo_schema_extensions = plugin.getProperty("userinfo_schema_extensions", [])
 
-    if not userinfo_schema_extensions:
+    if len(userinfo_schema_extensions) == 0:
         return message.OpenIDSchema
 
     types = {
@@ -215,8 +209,10 @@ def extend_user_info_schema(plugin) -> type[message.OpenIDSchema]:
             return {
                 **message.OpenIDSchema.c_param,
                 **{
-                    key: types[parser_id]
-                    for key, parser_id in userinfo_schema_extensions.items()
+                    extension[0]: types[extension[1]]
+                    for extension in [
+                        extension.split(":") for extension in userinfo_schema_extensions
+                    ]
                 },
             }
 

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -12,10 +12,12 @@ from oic.oauth2.message import (
     REQUIRED_LIST_OF_SP_SEP_STRINGS,
     SINGLE_OPTIONAL_JSON,
 )
+from zope.interface import Invalid
 from pas.plugins.oidc import logger
 from pas.plugins.oidc import plugins
 from pas.plugins.oidc.plugins import OIDCPlugin
 from pas.plugins.oidc.session import Session
+from pas.plugins.oidc import _
 from plone import api
 
 import base64
@@ -184,11 +186,50 @@ def parse_authorization_response(
     return args, aresp["state"]
 
 
+def validate_userinfo_schema_extension(values):
+    valid_types = [
+        "SINGLE_REQUIRED_STRING",
+        "SINGLE_OPTIONAL_STRING",
+        "SINGLE_OPTIONAL_INT",
+        "OPTIONAL_LIST_OF_STRINGS",
+        "REQUIRED_LIST_OF_STRINGS",
+        "OPTIONAL_LIST_OF_SP_SEP_STRINGS",
+        "REQUIRED_LIST_OF_SP_SEP_STRINGS",
+        "SINGLE_OPTIONAL_JSON",
+    ]
+
+    for value in values:
+        split_value = value.split(":")
+        if len(split_value) > 2 or len(split_value) < 2:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"A line can only consist of <key>:<type>. {values} is given",
+                )
+            )
+        if split_value[1] not in valid_types:
+            raise Invalid(
+                _(
+                    "invalid userinfo_schema_extensions",
+                    f"Type {split_value[1]} not valid for {split_value[0]}",
+                )
+            )
+
+    return True
+
+
 def extend_user_info_schema(plugin) -> type[message.OpenIDSchema]:
 
     userinfo_schema_extensions = plugin.getProperty("userinfo_schema_extensions", [])
 
     if len(userinfo_schema_extensions) == 0:
+        return message.OpenIDSchema
+
+    try:
+        validate_userinfo_schema_extension(userinfo_schema_extensions)
+    except Invalid as e:
+        logger.error("invalid userinfo_schema_extensions")
+        logger.error(e)
         return message.OpenIDSchema
 
     types = {

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -2,6 +2,16 @@ from hashlib import sha256
 from oic import rndstr
 from oic.exception import RequestError
 from oic.oic import message
+from oic.oauth2.message import (
+    SINGLE_REQUIRED_STRING,
+    SINGLE_OPTIONAL_STRING,
+    SINGLE_OPTIONAL_INT,
+    OPTIONAL_LIST_OF_STRINGS,
+    REQUIRED_LIST_OF_STRINGS,
+    OPTIONAL_LIST_OF_SP_SEP_STRINGS,
+    REQUIRED_LIST_OF_SP_SEP_STRINGS,
+    SINGLE_OPTIONAL_JSON,
+)
 from pas.plugins.oidc import logger
 from pas.plugins.oidc import plugins
 from pas.plugins.oidc.plugins import OIDCPlugin
@@ -174,7 +184,39 @@ def parse_authorization_response(
     return args, aresp["state"]
 
 
-def get_user_info(client, state, args, method="POST") -> message.OpenIDSchema | dict:
+def extend_user_info_schema(
+    extensions: dict | None = None,
+) -> type[message.OpenIDSchema]:
+
+    if extensions is None:
+        return message.OpenIDSchema
+
+    types = {
+        "SINGLE_REQUIRED_STRING": SINGLE_REQUIRED_STRING,
+        "SINGLE_OPTIONAL_STRING": SINGLE_OPTIONAL_STRING,
+        "SINGLE_OPTIONAL_INT": SINGLE_OPTIONAL_INT,
+        "OPTIONAL_LIST_OF_STRINGS": OPTIONAL_LIST_OF_STRINGS,
+        "REQUIRED_LIST_OF_STRINGS": REQUIRED_LIST_OF_STRINGS,
+        "OPTIONAL_LIST_OF_SP_SEP_STRINGS": OPTIONAL_LIST_OF_SP_SEP_STRINGS,
+        "REQUIRED_LIST_OF_SP_SEP_STRINGS": REQUIRED_LIST_OF_SP_SEP_STRINGS,
+        "SINGLE_OPTIONAL_JSON": SINGLE_OPTIONAL_JSON,
+    }
+
+    class ExntendedOpenIDSchema(message.OpenIDSchema):
+
+        @property
+        def c_param(self) -> dict:
+            return {
+                **message.OpenIDSchema.c_param,
+                **{key: types[parser_id] for key, parser_id in extensions.items()},
+            }
+
+    return ExntendedOpenIDSchema
+
+
+def get_user_info(
+    client, state, args, method="POST", user_info_schema_extensions: dict | None = None
+) -> message.OpenIDSchema | dict:
     resp = client.do_access_token_request(
         state=state,
         request_args=args,
@@ -188,7 +230,13 @@ def get_user_info(client, state, args, method="POST") -> message.OpenIDSchema | 
         if client.userinfo_endpoint:
             # https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
             try:
-                user_info = client.do_user_info_request(method=method, state=state)
+                user_info = client.do_user_info_request(
+                    method=method,
+                    state=state,
+                    user_info_schema=extend_user_info_schema(
+                        user_info_schema_extensions
+                    ),
+                )
             except RequestError as exc:
                 logger.error(
                     "Authentication failed, probably missing openid scope",

--- a/src/pas/plugins/oidc/utils.py
+++ b/src/pas/plugins/oidc/utils.py
@@ -184,11 +184,17 @@ def parse_authorization_response(
     return args, aresp["state"]
 
 
-def extend_user_info_schema(
-    extensions: dict | None = None,
-) -> type[message.OpenIDSchema]:
+def extend_user_info_schema(plugin) -> type[message.OpenIDSchema]:
 
-    if extensions is None:
+    try:
+        userinfo_schema_extensions = json.loads(
+            plugin.getProperty("userinfo_schema_extensions", "{}")
+        )
+    except json.JSONDecodeError as e:
+        logger.error(e)
+        return message.OpenIDSchema
+
+    if not userinfo_schema_extensions:
         return message.OpenIDSchema
 
     types = {
@@ -208,14 +214,21 @@ def extend_user_info_schema(
         def c_param(self) -> dict:
             return {
                 **message.OpenIDSchema.c_param,
-                **{key: types[parser_id] for key, parser_id in extensions.items()},
+                **{
+                    key: types[parser_id]
+                    for key, parser_id in userinfo_schema_extensions.items()
+                },
             }
 
     return ExntendedOpenIDSchema
 
 
 def get_user_info(
-    client, state, args, method="POST", user_info_schema_extensions: dict | None = None
+    client,
+    state,
+    args,
+    method="POST",
+    user_info_schema: type[message.OpenIDSchema] = message.OpenIDSchema,
 ) -> message.OpenIDSchema | dict:
     resp = client.do_access_token_request(
         state=state,
@@ -233,9 +246,7 @@ def get_user_info(
                 user_info = client.do_user_info_request(
                     method=method,
                     state=state,
-                    user_info_schema=extend_user_info_schema(
-                        user_info_schema_extensions
-                    ),
+                    user_info_schema=user_info_schema,
                 )
             except RequestError as exc:
                 logger.error(


### PR DESCRIPTION
Allow user info schema customization to correctly parse Oauth spec lists. should fix: #88 

The idea is to configure a list of values of the style `<claim>:<ParamDefinitionName>`
During the get_user_info step the configuration is parsed into its corresponding ParamDefinition form [oic/oauth2/message.py](https://github.com/CZ-NIC/pyoidc/blob/4b155c893c2ec21298be59541e647a0e98d5d7b8/src/oic/oauth2/message.py#L903):
```
SINGLE_REQUIRED_STRING = ParamDefinition(str, True, None, None, False)
SINGLE_OPTIONAL_STRING = ParamDefinition(str, False, None, None, False)
SINGLE_OPTIONAL_INT = ParamDefinition(int, False, None, None, False)
OPTIONAL_LIST_OF_STRINGS = ParamDefinition([str], False, list_serializer, list_deserializer, False)
REQUIRED_LIST_OF_STRINGS = ParamDefinition([str], True, list_serializer, list_deserializer, False)
OPTIONAL_LIST_OF_SP_SEP_STRINGS = ParamDefinition([str], False, sp_sep_list_serializer, sp_sep_list_deserializer, False)
REQUIRED_LIST_OF_SP_SEP_STRINGS = ParamDefinition([str], True, sp_sep_list_serializer, sp_sep_list_deserializer, False)
SINGLE_OPTIONAL_JSON = ParamDefinition(str, False, json_serializer, json_deserializer, False)
``` 

The OpenIDSchema from [oic/message.py](https://github.com/CZ-NIC/pyoidc/blob/4b155c893c2ec21298be59541e647a0e98d5d7b8/src/oic/oic/message.py#L522) is now extended and the claim can be parsed correctly by the pyoidc package.

I didn't get a better idea for configuration. JSONField in the plone ui clashed somehow with the acl_users ui.